### PR TITLE
Normalize "builtin" lambdas by saturating with free vars

### DIFF
--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -3,6 +3,7 @@ version: 0.1.0
 cabal-version: 2.0
 build-type: Simple
 license: MIT
+license-file: LICENSE
 homepage: https://github.com/ocharles/dhall-to-cabal
 bug-reports: https://github.com/ocharles/dhall-to-cabal/issues
 
@@ -13,8 +14,6 @@ source-repository head
 library
     exposed-modules:
         Distribution.Package.Dhall
-    other-modules: Version
-     VersionRange
     build-depends:
         Cabal ^>=2.0,
         base ^>=4.10,
@@ -32,6 +31,8 @@ library
     hs-source-dirs: lib
     other-modules:
         Dhall.Extra
+        Version
+        VersionRange
     ghc-options: -Wall -fno-warn-name-shadowing
 
 executable  dhall-to-cabal
@@ -62,4 +63,3 @@ test-suite  golden-tests
         tasty-golden ^>=2.3,
         text ^>=1.2
     hs-source-dirs: golden-tests
-

--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -13,6 +13,8 @@ source-repository head
 library
     exposed-modules:
         Distribution.Package.Dhall
+    other-modules: Version
+     VersionRange
     build-depends:
         Cabal ^>=2.0,
         base ^>=4.10,

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -93,7 +93,7 @@ in    stdlib.GitHub-project { owner = "ocharles", repo = "dhall-to-cabal" }
                   , stdlib.`constructors`.Extensions.TypeApplications True
                   ]
               , other-modules =
-                  [ "Dhall.Extra" ]
+                  [ "Dhall.Extra", "Version", "VersionRange" ]
               }
           )
       , executables =

--- a/lib/Version.hs
+++ b/lib/Version.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+
+module Version where
+
+import qualified Dhall.Core as Dhall ( Expr )
+import qualified Dhall.Core as Expr ( Expr(..), Var(..) )
+
+
+pattern Type :: Dhall.Expr s a
+pattern Type =
+  Expr.Var ( Expr.V "Version" 0 )
+
+
+
+pattern V :: Dhall.Expr s a
+pattern V =
+  Expr.Var ( Expr.V "v" 0 )

--- a/lib/VersionRange.hs
+++ b/lib/VersionRange.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+
+module VersionRange where
+
+import qualified Dhall.Core as Dhall ( Expr )
+import qualified Dhall.Core as Expr ( Expr(..), Var(..) )
+
+
+pattern Type :: Dhall.Expr s a
+pattern Type =
+  Expr.Var ( Expr.V "VersionRange" 0 )
+
+
+
+pattern AnyVersion :: Dhall.Expr s a
+pattern AnyVersion =
+  Expr.Var ( Expr.V "anyVersion" 0 )
+
+
+
+pattern NoVersion :: Dhall.Expr s a
+pattern NoVersion =
+  Expr.Var ( Expr.V "noVersion" 0 )
+
+
+
+pattern ThisVersion :: Dhall.Expr s a
+pattern ThisVersion =
+  Expr.Var ( Expr.V "thisVersion" 0 )
+
+
+
+pattern NotThisVersion :: Dhall.Expr s a
+pattern NotThisVersion =
+  Expr.Var ( Expr.V "notThisVersion" 0 )
+
+
+
+pattern LaterVersion :: Dhall.Expr s a
+pattern LaterVersion =
+  Expr.Var ( Expr.V "laterVersion" 0 )
+
+
+
+pattern EarlierVersion :: Dhall.Expr s a
+pattern EarlierVersion =
+  Expr.Var ( Expr.V "earlierVersion" 0 )
+
+
+
+pattern OrLaterVersion :: Dhall.Expr s a
+pattern OrLaterVersion =
+  Expr.Var ( Expr.V "orLaterVersion" 0 )
+
+
+
+pattern OrEarlierVersion :: Dhall.Expr s a
+pattern OrEarlierVersion =
+  Expr.Var ( Expr.V "orEarlierVersion" 0 )
+
+
+
+pattern WithinVersion :: Dhall.Expr s a
+pattern WithinVersion =
+  Expr.Var ( Expr.V "withinVersion" 0 )
+
+
+
+pattern MajorBoundVersion :: Dhall.Expr s a
+pattern MajorBoundVersion =
+  Expr.Var ( Expr.V "majorBoundVersion" 0 )
+
+
+
+pattern UnionVersionRanges :: Dhall.Expr s a
+pattern UnionVersionRanges =
+  Expr.Var ( Expr.V "unionVersionRanges" 0 )
+
+
+
+pattern IntersectVersionRanges :: Dhall.Expr s a
+pattern IntersectVersionRanges =
+  Expr.Var ( Expr.V "intersectVersionRanges" 0 )
+
+
+
+pattern DifferenceVersionRanges :: Dhall.Expr s a
+pattern DifferenceVersionRanges =
+  Expr.Var ( Expr.V "differenceVersionRanges" 0 )
+
+
+
+pattern InvertVersionRange :: Dhall.Expr s a
+pattern InvertVersionRange =
+  Expr.Var ( Expr.V "invertVersionRange" 0 )


### PR DESCRIPTION
I think just walking under a lambda without checking for the names of binding is
unsound. Rather than mandate the naming of variables, just saturate the lambda
with the application of known free variable names.