### PR TITLE
Change guarding to be a top level function per component

### DIFF
--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -19,7 +19,6 @@ library
     build-depends:
         Cabal ^>=2.0,
         base ^>=4.10,
-        lens,
         bytestring ^>=0.10,
         containers ^>=0.5,
         insert-ordered-containers ^>=0.2.1.0,

--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -13,9 +13,8 @@ source-repository head
 library
     exposed-modules:
         Distribution.Package.Dhall
-    other-modules: Version
-     VersionRange
-     DhallToCabal.ConfigTree
+    other-modules:
+        DhallToCabal.ConfigTree
     build-depends:
         Cabal ^>=2.0,
         base ^>=4.10,

--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -13,9 +13,13 @@ source-repository head
 library
     exposed-modules:
         Distribution.Package.Dhall
+    other-modules: Version
+     VersionRange
+     DhallToCabal.ConfigTree
     build-depends:
         Cabal ^>=2.0,
         base ^>=4.10,
+        lens,
         bytestring ^>=0.10,
         containers ^>=0.5,
         insert-ordered-containers ^>=0.2.1.0,

--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -3,6 +3,7 @@ version: 0.1.0
 cabal-version: 2.0
 build-type: Simple
 license: MIT
+license-file: LICENSE
 homepage: https://github.com/ocharles/dhall-to-cabal
 bug-reports: https://github.com/ocharles/dhall-to-cabal/issues
 
@@ -13,9 +14,6 @@ source-repository head
 library
     exposed-modules:
         Distribution.Package.Dhall
-    other-modules:
-        DhallToCabal.ConfigTree
-        DhallToCabal.Diff
     build-depends:
         Cabal ^>=2.0,
         base ^>=4.10,
@@ -32,6 +30,8 @@ library
                       LambdaCase OverloadedStrings RecordWildCards TypeApplications
     hs-source-dirs: lib
     other-modules:
+        DhallToCabal.ConfigTree
+        DhallToCabal.Diff
         Dhall.Extra
     ghc-options: -Wall -fno-warn-name-shadowing
 

--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -15,6 +15,7 @@ library
         Distribution.Package.Dhall
     other-modules:
         DhallToCabal.ConfigTree
+        DhallToCabal.Diff
     build-depends:
         Cabal ^>=2.0,
         base ^>=4.10,

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -93,7 +93,10 @@ in    stdlib.GitHub-project { owner = "ocharles", repo = "dhall-to-cabal" }
                   , stdlib.`constructors`.Extensions.TypeApplications True
                   ]
               , other-modules =
-                  [ "Dhall.Extra" ]
+                  [ "DhallToCabal.ConfigTree"
+                  , "DhallToCabal.Diff"
+                  , "Dhall.Extra"
+                  ]
               }
           )
       , executables =

--- a/dhall/types/Guarded.dhall
+++ b/dhall/types/Guarded.dhall
@@ -1,1 +1,1 @@
-λ(A : Type) → List { body : A, guard : ./Config.dhall  → Bool }
+λ(A : Type) → ./Config.dhall  → A

--- a/dhall/unconditional.dhall
+++ b/dhall/unconditional.dhall
@@ -1,8 +1,6 @@
     let unconditional
         : ∀(A : Type) → A → ./types/Guarded.dhall  A
-        =   λ(A : Type)
-          → λ(a : A)
-          → [ { guard = λ(_ : ./types/Config.dhall ) → True, body = a } ]
+        = λ(A : Type) → λ(a : A) → λ(_ : ./types/Config.dhall ) → a
 
 in  let executable
         :   ∀(name : Text)

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -44,7 +44,6 @@ data KnownType
   | Executable
   | Benchmark
   | TestSuite
-  | Guard
   | SourceRepo
   | RepoType
   | RepoKind
@@ -204,7 +203,6 @@ printType t = do
         License -> Dhall.expected license
         BuildType -> Dhall.expected buildType
         Package -> Dhall.expected genericPackageDescription
-        Guard -> Dhall.expected guard
 
     letDhallType t =
       liftCSE ( fromString ( show t ) ) ( dhallType t )

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -44,6 +44,7 @@ data KnownType
   | Executable
   | Benchmark
   | TestSuite
+  | Config
   | SourceRepo
   | RepoType
   | RepoKind
@@ -56,6 +57,8 @@ data KnownType
   | License
   | BuildType
   | Package
+  | VersionRange
+  | Version
   deriving (Bounded, Enum, Eq, Ord, Read, Show)
 
 
@@ -186,6 +189,7 @@ printType t = do
 
     dhallType t =
       case t of
+        Config -> configRecordType
         Library -> Dhall.expected library
         ForeignLibrary -> Dhall.expected foreignLib
         Executable -> Dhall.expected executable
@@ -203,6 +207,8 @@ printType t = do
         License -> Dhall.expected license
         BuildType -> Dhall.expected buildType
         Package -> Dhall.expected genericPackageDescription
+        VersionRange -> Dhall.expected versionRange
+        Version -> Dhall.expected version
 
     letDhallType t =
       liftCSE ( fromString ( show t ) ) ( dhallType t )

--- a/lib/DhallToCabal/ConfigTree.hs
+++ b/lib/DhallToCabal/ConfigTree.hs
@@ -1,0 +1,172 @@
+{-# language DeriveFunctor #-}
+{-# language LambdaCase #-}
+{-# language OverloadedStrings #-}
+
+module DhallToCabal.ConfigTree ( ConfigTree(..), toConfigTree ) where
+
+import Control.Applicative
+import Control.Lens (deepOf)
+import Data.Functor.Identity
+import Data.Monoid
+import Dhall.Core hiding (Const)
+
+
+
+data ConfigTree a
+  = Leaf a
+  | Branch a ( ConfigTree a ) ( ConfigTree a )
+  deriving (Functor, Show)
+
+
+
+toConfigTree :: ( Eq a, Eq s ) => Expr s a -> ConfigTree ( Expr s a )
+toConfigTree e = 
+  let
+    v =
+      "config"
+    
+    saturated =
+      normalize (App e (Var v))
+
+    loop e =
+      let
+        Const condition =
+          deepOf
+            subExpr
+            ( findConfigUse v )
+            ( Const . First . Just ) e
+
+      in
+        case condition of
+          First Nothing ->
+            Leaf e
+
+          First (Just cond) ->
+            let
+              replaceWith x =
+                loop
+                  . normalize
+                  . runIdentity
+                  . deepOf
+                      subExpr
+                      ( exactly cond )
+                      ( const ( pure x ) )
+            
+            in
+              Branch
+                cond
+                ( replaceWith ( BoolLit True ) e )
+                ( replaceWith ( BoolLit False ) e )
+
+  in loop saturated
+
+
+
+findConfigUse
+  :: Applicative f
+  => Var -> ( Expr s a -> f ( Expr s a ) ) -> Expr s a -> f ( Expr s a )
+findConfigUse x f e@(App (Field (Var x') "os") _) | x == x' = f e
+findConfigUse x f e@(App (Field (Var x') "arch") _) | x == x' = f e
+findConfigUse x f e@(App (App (Field (Var x') "impl") _) _) | x == x' = f e
+findConfigUse x f e@(App (Field (Var x') "flag") _) | x == x' = f e
+findConfigUse _ _ e = pure e
+
+
+
+exactly :: ( Applicative f, Eq a ) => a -> ( a -> f a ) -> a -> f a
+exactly x f e | x == e = f e
+exactly _ _ e = pure e
+
+
+
+subExpr
+  :: Applicative f
+  => ( Expr s a -> f ( Expr s a ) ) -> Expr s a -> f ( Expr s a ) 
+subExpr f = \case
+  Lam a b c ->
+    Lam a <$> f b <*> f c
+
+  Pi a b c ->
+    Pi a <$> f b <*> f c
+
+  App a b ->
+    App <$> f a <*> f b 
+
+  Let a b c d ->
+    Let a <$> traverse f b <*> f c <*> f d
+
+  Annot a b ->
+    Annot <$> f a <*> f b
+
+  BoolAnd a b ->
+    BoolAnd <$> f a <*> f b
+
+  BoolOr a b -> 
+    BoolOr <$> f a <*> f b
+
+  BoolEQ a b ->
+    BoolEQ <$> f a <*> f b
+    
+  BoolNE a b ->
+    BoolNE <$> f a <*> f b
+    
+  BoolIf a b c ->
+    BoolIf <$> f a <*> f b <*> f c
+    
+  NaturalPlus a b ->
+    NaturalPlus <$> f a <*> f b
+    
+  NaturalTimes a b ->
+    NaturalTimes <$> f a <*> f b
+    
+  TextLit (Chunks a b) ->
+    TextLit
+      <$>
+        ( Chunks
+            <$> traverse ( \(a,b) -> (,) <$> pure a <*> f b ) a <*> pure b
+        )
+    
+  TextAppend a b ->
+    TextAppend <$> f a <*> f b
+    
+  ListLit a b ->
+    ListLit <$> traverse f a <*> traverse f b
+    
+  ListAppend a b ->
+    ListAppend <$> f a <*> f b
+    
+  OptionalLit a b ->
+    OptionalLit <$> f a <*> traverse f b
+    
+  Record a ->
+    Record <$> traverse f a
+    
+  RecordLit a ->
+    RecordLit <$> traverse f a
+    
+  Union a ->
+    Union <$> traverse f a
+    
+  UnionLit a b c ->
+    UnionLit a <$> f b <*> traverse f c
+    
+  Combine a b ->
+    Combine <$> f a <*> f b
+    
+  Prefer a b ->
+    Prefer <$> f a <*> f b
+    
+  Merge a b t ->
+    Merge <$> f a <*> f b <*> traverse f t
+    
+  Constructors a ->
+    Constructors <$> f a
+    
+  Field a b ->
+    Field <$> f a <*> pure b
+    
+  Note a b ->
+    Note a <$> f b
+    
+  e ->
+    pure e

--- a/lib/DhallToCabal/ConfigTree.hs
+++ b/lib/DhallToCabal/ConfigTree.hs
@@ -12,19 +12,19 @@ import Dhall.Core hiding (Const)
 
 
 
-data ConfigTree a
+data ConfigTree cond a
   = Leaf a
-  | Branch a ( ConfigTree a ) ( ConfigTree a )
+  | Branch cond ( ConfigTree cond a ) ( ConfigTree cond a )
   deriving (Functor, Show)
 
 
 
-toConfigTree :: ( Eq a, Eq s ) => Expr s a -> ConfigTree ( Expr s a )
-toConfigTree e = 
+toConfigTree :: ( Eq a, Eq s ) => Expr s a -> ConfigTree ( Expr s a ) ( Expr s a )
+toConfigTree e =
   let
     v =
       "config"
-    
+
     saturated =
       normalize (App e (Var v))
 
@@ -51,7 +51,7 @@ toConfigTree e =
                       subExpr
                       ( exactly cond )
                       ( const ( pure x ) )
-            
+
             in
               Branch
                 cond
@@ -81,7 +81,7 @@ exactly _ _ e = pure e
 
 subExpr
   :: Applicative f
-  => ( Expr s a -> f ( Expr s a ) ) -> Expr s a -> f ( Expr s a ) 
+  => ( Expr s a -> f ( Expr s a ) ) -> Expr s a -> f ( Expr s a )
 subExpr f = \case
   Lam a b c ->
     Lam a <$> f b <*> f c
@@ -90,7 +90,7 @@ subExpr f = \case
     Pi a <$> f b <*> f c
 
   App a b ->
-    App <$> f a <*> f b 
+    App <$> f a <*> f b
 
   Let a b c d ->
     Let a <$> traverse f b <*> f c <*> f d
@@ -101,72 +101,72 @@ subExpr f = \case
   BoolAnd a b ->
     BoolAnd <$> f a <*> f b
 
-  BoolOr a b -> 
+  BoolOr a b ->
     BoolOr <$> f a <*> f b
 
   BoolEQ a b ->
     BoolEQ <$> f a <*> f b
-    
+
   BoolNE a b ->
     BoolNE <$> f a <*> f b
-    
+
   BoolIf a b c ->
     BoolIf <$> f a <*> f b <*> f c
-    
+
   NaturalPlus a b ->
     NaturalPlus <$> f a <*> f b
-    
+
   NaturalTimes a b ->
     NaturalTimes <$> f a <*> f b
-    
+
   TextLit (Chunks a b) ->
     TextLit
       <$>
         ( Chunks
             <$> traverse ( \(a,b) -> (,) <$> pure a <*> f b ) a <*> pure b
         )
-    
+
   TextAppend a b ->
     TextAppend <$> f a <*> f b
-    
+
   ListLit a b ->
     ListLit <$> traverse f a <*> traverse f b
-    
+
   ListAppend a b ->
     ListAppend <$> f a <*> f b
-    
+
   OptionalLit a b ->
     OptionalLit <$> f a <*> traverse f b
-    
+
   Record a ->
     Record <$> traverse f a
-    
+
   RecordLit a ->
     RecordLit <$> traverse f a
-    
+
   Union a ->
     Union <$> traverse f a
-    
+
   UnionLit a b c ->
     UnionLit a <$> f b <*> traverse f c
-    
+
   Combine a b ->
     Combine <$> f a <*> f b
-    
+
   Prefer a b ->
     Prefer <$> f a <*> f b
-    
+
   Merge a b t ->
     Merge <$> f a <*> f b <*> traverse f t
-    
+
   Constructors a ->
     Constructors <$> f a
-    
+
   Field a b ->
     Field <$> f a <*> pure b
-    
+
   Note a b ->
     Note a <$> f b
-    
+
   e ->
     pure e

--- a/lib/DhallToCabal/Diff.hs
+++ b/lib/DhallToCabal/Diff.hs
@@ -1,0 +1,217 @@
+{-# language DefaultSignatures #-}
+{-# language FlexibleContexts #-}
+{-# language TypeOperators #-}
+
+module DhallToCabal.Diff ( Diffable(..) ) where
+
+import Data.List ( (\\), intersect )
+
+import qualified Distribution.PackageDescription as Cabal
+import qualified Distribution.Types.ExecutableScope as Cabal
+import qualified Distribution.Types.ForeignLib as Cabal
+import qualified Distribution.Types.ForeignLibType as Cabal
+import qualified Distribution.Types.UnqualComponentName as Cabal
+import qualified GHC.Generics as Generic
+
+
+
+diffEqVia :: ( Monoid a, Eq b ) => ( a -> b ) -> a -> a -> ( b, b, b )
+diffEqVia f left right =
+  if f left == f right then
+    ( f left, f mempty, f mempty )
+  else
+    ( f mempty, f left, f right )
+
+
+
+class Diffable a where
+  diff :: a -> a -> ( a, a, a )
+  default diff :: ( Generic.Generic a, GDiffable ( Generic.Rep a ) ) => a -> a -> ( a, a, a )
+  diff a b =
+    let
+      ( common, left, right ) =
+        gdiff ( Generic.from a ) ( Generic.from b )
+
+    in
+      ( Generic.to common, Generic.to left, Generic.to right )
+
+
+
+instance Diffable Cabal.BuildInfo where
+  diff a b =
+    let
+      ( commonBuildable, leftBuildable, rightBuildable ) =
+        diffEqVia Cabal.buildable a b
+
+      ( common, left, right ) =
+        case gdiff ( Generic.from a ) ( Generic.from b ) of
+          ( common, left, right ) ->
+            ( Generic.to common, Generic.to left, Generic.to right )
+
+    in
+      ( common { Cabal.buildable = commonBuildable }
+      , left { Cabal.buildable = leftBuildable }
+      , right { Cabal.buildable = rightBuildable }
+      )
+
+
+
+instance Diffable Cabal.Library where
+  diff a b =
+    let
+      ( commonLibExposed, leftLibExposed, rightLibExposed ) =
+        diffEqVia Cabal.libExposed a b
+
+      ( common, left, right ) =
+        case gdiff ( Generic.from a ) ( Generic.from b ) of
+          ( common, left, right ) ->
+            ( Generic.to common, Generic.to left, Generic.to right )
+
+    in
+      ( common { Cabal.libExposed = commonLibExposed }
+      , left { Cabal.libExposed = leftLibExposed }
+      , right { Cabal.libExposed = rightLibExposed }
+      )
+
+
+instance Diffable Cabal.Benchmark
+
+
+
+instance Diffable Cabal.TestSuite
+
+
+
+instance Diffable Cabal.Executable where
+  diff a b =
+    let
+      ( commonModulePath, leftModulePath, rightModulePath ) =
+        diffEqVia Cabal.modulePath a b
+
+      ( common, left, right ) =
+        case gdiff ( Generic.from a ) ( Generic.from b ) of
+          ( common, left, right ) ->
+            ( Generic.to common, Generic.to left, Generic.to right )
+
+    in
+      ( common { Cabal.modulePath = commonModulePath }
+      , left { Cabal.modulePath = leftModulePath }
+      , right { Cabal.modulePath = rightModulePath }
+      )
+
+
+
+instance Diffable Cabal.ForeignLib
+
+
+
+instance Eq a => Diffable ( Maybe a ) where
+  diff left right =
+    if left == right then
+      ( left, Nothing, Nothing )
+    else
+      ( Nothing, left, right )
+
+
+
+instance Diffable Cabal.UnqualComponentName where
+  diff left right =
+    if left == right then
+      ( left, mempty, mempty )
+    else
+      ( mempty, left, right )
+
+
+
+instance Diffable Cabal.BenchmarkInterface where
+  diff left right =
+    if left == right then
+      ( left, mempty, mempty )
+    else
+      ( mempty, left, right )
+
+
+
+instance Diffable Cabal.ForeignLibType where
+  diff left right =
+    if left == right then
+      ( left, mempty, mempty )
+    else
+      ( mempty, left, right )
+
+
+
+instance Diffable Cabal.TestSuiteInterface where
+  diff left right =
+    if left == right then
+      ( left, mempty, mempty )
+    else
+      ( mempty, left, right )
+
+
+
+instance Diffable Cabal.ExecutableScope where
+  diff left right =
+    if left == right then
+      ( left, mempty, mempty )
+    else
+      ( mempty, left, right )
+
+
+
+instance Eq a => Diffable [a] where
+  diff a b =
+    ( intersect a b
+    , a \\ b
+    , b \\ a
+    )
+
+
+
+instance Diffable Bool where
+  diff left right =
+    if left == right then
+      ( left, True, True )
+    else
+      ( True, left, right )
+
+
+
+class GDiffable f where
+  gdiff :: f a -> f a -> ( f a, f a, f a )
+
+
+
+instance GDiffable f => GDiffable ( Generic.M1 i c f ) where
+  gdiff ( Generic.M1 a ) ( Generic.M1 b ) =
+    let
+      ( common, left, right ) =
+        gdiff a b
+
+    in
+      ( Generic.M1 common, Generic.M1 left, Generic.M1 right )
+
+
+
+instance ( GDiffable f, GDiffable g ) => GDiffable ( f Generic.:*: g ) where
+  gdiff ( a Generic.:*: x ) ( b Generic.:*: y ) =
+    let
+      ( common0, left0, right0 ) =
+        gdiff a b
+
+      ( common1, left1, right1 ) =
+        gdiff x y
+
+    in
+      ( common0 Generic.:*: common1, left0 Generic.:*: left1, right0 Generic.:*: right1 )
+
+
+
+instance Diffable a => GDiffable ( Generic.K1 i a ) where
+  gdiff ( Generic.K1 a ) ( Generic.K1 b ) =
+    let
+      ( common, left, right ) =
+        diff a b
+
+    in
+      ( Generic.K1 common, Generic.K1 left, Generic.K1 right )

--- a/lib/Distribution/Package/Dhall.hs
+++ b/lib/Distribution/Package/Dhall.hs
@@ -1008,7 +1008,7 @@ guarded t =
 
     configTreeToCondTree = \case
       Leaf a -> do
-        Cabal.CondNode <$> maybe ( error ( LazyText.unpack ( Dhall.Core.pretty a ) ) ) Just ( Dhall.extract t a ) <*> pure mempty <*> pure mempty
+        Cabal.CondNode <$> Dhall.extract t a <*> pure mempty <*> pure mempty
 
       Branch cond a b ->
         Cabal.CondNode

--- a/lib/Distribution/Package/Dhall.hs
+++ b/lib/Distribution/Package/Dhall.hs
@@ -29,6 +29,9 @@ module Distribution.Package.Dhall
   , benchmark
   , foreignLib
   , buildType
+  , versionRange
+  , version
+  , configRecordType
   ) where
 
 import Control.Exception ( Exception, throwIO )
@@ -1024,28 +1027,32 @@ guarded t =
                 )
 
     expected =
-      let
-        predicate on =
-          Expr.Pi "_" on Expr.Bool
-
-        configRecord =
-          Expr.Record
-            ( Map.fromList
-                [ ( "os", predicate ( Dhall.expected operatingSystem ) )
-                , ( "arch", predicate ( Dhall.expected arch ) )
-                , ( "flag", predicate ( Dhall.expected flagName ) )
-                , ( "impl"
-                  , Expr.Pi
-                      "_"
-                      ( Dhall.expected compilerFlavor )
-                      ( Expr.Pi "_" ( Dhall.expected versionRange ) Expr.Bool )
-                  )
-                ]
-            )
-      in
-        Expr.Pi "_" configRecord ( Dhall.expected t )
+        Expr.Pi "_" configRecordType ( Dhall.expected t )
 
   in Dhall.Type { .. }
+
+
+
+configRecordType :: Expr.Expr Dhall.Parser.Src Dhall.TypeCheck.X
+configRecordType =
+  let
+    predicate on =
+      Expr.Pi "_" on Expr.Bool
+
+  in
+    Expr.Record
+      ( Map.fromList
+          [ ( "os", predicate ( Dhall.expected operatingSystem ) )
+          , ( "arch", predicate ( Dhall.expected arch ) )
+          , ( "flag", predicate ( Dhall.expected flagName ) )
+          , ( "impl"
+            , Expr.Pi
+                "_"
+                ( Dhall.expected compilerFlavor )
+                ( Expr.Pi "_" ( Dhall.expected versionRange ) Expr.Bool )
+            )
+          ]
+      )
 
 
 

--- a/lib/Distribution/Package/Dhall.hs
+++ b/lib/Distribution/Package/Dhall.hs
@@ -999,7 +999,7 @@ guarded t =
       configTreeToCondTree <$> extractConfigTree ( toConfigTree expr )
 
     extractConfigTree ( Leaf a ) =
-      Leaf <$> Dhall.extract t a
+      Leaf <$> ( maybe ( error ( show a )) Just $ Dhall.extract t a)
 
     extractConfigTree ( Branch cond a b ) =
       Branch <$> extractGuard cond <*> extractConfigTree a <*> extractConfigTree b

--- a/lib/Distribution/Package/Dhall.hs
+++ b/lib/Distribution/Package/Dhall.hs
@@ -999,7 +999,7 @@ guarded t =
       configTreeToCondTree <$> extractConfigTree ( toConfigTree expr )
 
     extractConfigTree ( Leaf a ) =
-      Leaf <$> ( maybe ( error ( show a )) Just $ Dhall.extract t a)
+      Leaf <$> Dhall.extract t a
 
     extractConfigTree ( Branch cond a b ) =
       Branch <$> extractGuard cond <*> extractConfigTree a <*> extractConfigTree b

--- a/lib/Distribution/Package/Dhall.hs
+++ b/lib/Distribution/Package/Dhall.hs
@@ -1045,7 +1045,7 @@ guarded t =
       in
         Expr.Pi "_" configRecord ( Dhall.expected t )
 
-  in Dhall.Type {..}
+  in Dhall.Type { .. }
 
 
 


### PR DESCRIPTION
This commit changes the guarding logic from:

  List { guard : Config -> Bool, body : A }

to simply

  Config -> A

This is achieved through the new ConfigTree type.

ConfigTree takes the unsaturated configuration lambda, and applies it with a
known variable name. Next, we find all uses of this variable w.r.t. config field
access and application. We then replace all occurances of these applications
with either True or False, building a tree of decisions as we go - this is the
ConfigTree.

With a ConfigTree extracted, it's trivial to then turn this into a
Cabal.CondTree.

This currently produces some verbose Cabal, but it's not going to be much work
to lift common elements up the tree and produce miminal Cabal files. This will
come in future work.