### PR TITLE
Add a default version number to defaults/Package.dhall.

### DIFF
--- a/dhall/defaults/Package.dhall
+++ b/dhall/defaults/Package.dhall
@@ -87,8 +87,10 @@
          , version :
              ../types/VersionRange.dhall 
          }
+, version =
+    ../types/Version/v.dhall "0"
 , x-fields =
     [] : List { _1 : Text, _2 : Text }
 , custom-setup =
-    [] : Optional ../types/SetupBuildInfo.dhall 
+    [] : Optional ../types/SetupBuildInfo.dhall
 }


### PR DESCRIPTION
There's already a default empty 'name' field, and this isn't worse
than that. It means that the default Package has the type from
types/Package.dhall, which is a win for short examples and hopefully
will reduce user surprise--I was surprised, and the type error was
far too enormous to work out what was going on.

Also removed an incidental trailing bit of whitespace.