### PR TITLE
Export more types through dhall/types.dhall.

### DIFF
--- a/dhall/types.dhall
+++ b/dhall/types.dhall
@@ -1,23 +1,31 @@
-{ Benchmark =
+{ Arch =
+    ./types/Arch.dhall
+, Benchmark =
     ./types/Benchmark.dhall 
 , BuildType =
     ./types/BuildType.dhall 
 , Compiler =
-    ./types/Compiler.dhall 
+    ./types/Compiler.dhall
 , CompilerOptions =
-    ./types/CompilerOptions.dhall 
+    ./types/CompilerOptions.dhall
 , ConfigOptions =
     ./types/Config.dhall 
 , CustomSetup =
-    ./types/CustomSetup.dhall 
+    ./types/CustomSetup.dhall
+, Dependency =
+    ./types/Dependency.dhall
 , Executable =
-    ./types/Executable.dhall 
+    ./types/Executable.dhall
 , Extension =
-    ./types/Extension.dhall 
+    ./types/Extension.dhall
 , Extensions =
-    ./types/Extension.dhall 
+    ./types/Extension.dhall
+, Flag =
+    ./types/Flag.dhall
 , ForeignLibrary =
-    ./types/ForeignLibrary.dhall 
+    ./types/ForeignLibrary.dhall
+, Guarded =
+    ./types/Guarded.dhall
 , Language =
     ./types/Language.dhall 
 , Languages =
@@ -27,15 +35,23 @@
 , License =
     ./types/License.dhall 
 , Mixin =
-    ./types/Mixin.dhall 
+    ./types/Mixin.dhall
+, ModuleRenaming =
+    ./types/ModuleRenaming.dhall
 , OS =
-    ./types/OS.dhall 
+    ./types/OS.dhall
 , RepoKind =
-    ./types/RepoKind.dhall 
+    ./types/RepoKind.dhall
 , RepoType =
-    ./types/RepoType.dhall 
+    ./types/RepoType.dhall
+, Scope =
+    ./types/Scope.dhall
+, SetupBuildInfo =
+    ./types/SetupBuildInfo.dhall
 , TestSuite =
-    ./types/TestSuite.dhall 
+    ./types/TestSuite.dhall
+, TestType =
+    ./types/TestType.dhall
 , Version =
     ./types/Version.dhall 
 , VersionRange =


### PR DESCRIPTION
This exports everything from dhall/types/*.dhall that's not obviously
internal, for user convenience.

Also more random trailing whitespace got removed in the process.