### PR TITLE
Rename types.ConfigOptions to types.Config.

### DIFF
--- a/cabal-to-dhall/Main.hs
+++ b/cabal-to-dhall/Main.hs
@@ -831,7 +831,7 @@ condTree t =
           ( go b )
 
     configRecord =
-      Expr.Var "types" `Expr.Field` "ConfigOptions"
+      Expr.Var "types" `Expr.Field` "Config"
 
   in
   Dhall.InputType

--- a/dhall/types.dhall
+++ b/dhall/types.dhall
@@ -8,7 +8,7 @@
     ./types/Compiler.dhall
 , CompilerOptions =
     ./types/CompilerOptions.dhall
-, ConfigOptions =
+, Config =
     ./types/Config.dhall 
 , CustomSetup =
     ./types/CustomSetup.dhall


### PR DESCRIPTION
This is consistent with the filename, and how it's used in the
examples.

Note that this is a breaking API change.