### PR TITLE
Also export Package from types.dhall.

### DIFF
--- a/dhall/types.dhall
+++ b/dhall/types.dhall
@@ -40,6 +40,8 @@
     ./types/ModuleRenaming.dhall
 , OS =
     ./types/OS.dhall
+, Package =
+    ./types/Package.dhall
 , RepoKind =
     ./types/RepoKind.dhall
 , RepoType =


### PR DESCRIPTION
Managed to miss this rather important one in #40. Oops.