### PR TITLE
Un-export Guarded from types.dhall

### DIFF
--- a/dhall/types.dhall
+++ b/dhall/types.dhall
@@ -24,8 +24,6 @@
     ./types/Flag.dhall
 , ForeignLibrary =
     ./types/ForeignLibrary.dhall
-, Guarded =
-    ./types/Guarded.dhall
 , Language =
     ./types/Language.dhall 
 , Languages =


### PR DESCRIPTION
Annoyingly, Guarded is higher-kinded and in Dhall 1.13 cannot be part
of a record.