### PR TITLE
Don't provide a default name for packages.

### DIFF
--- a/dhall/defaults/Package.dhall
+++ b/dhall/defaults/Package.dhall
@@ -56,8 +56,6 @@
     [] : List Text
 , maintainer =
     ""
-, name =
-    ""
 , package-url =
     ""
 , source-repos =


### PR DESCRIPTION
Along with version, this is one of the fields that it just doesn't
make sense to do without.