### PR TITLE
Upgrade to Dhall 1.14.

### DIFF
--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -94,7 +94,7 @@ library
         bytestring ^>=0.10,
         containers ^>=0.5,
         contravariant ^>=1.4,
-        dhall ^>=1.13.0,
+        dhall ^>=1.14.0,
         formatting ^>=6.3.1,
         hashable ^>=1.2.6.1,
         insert-ordered-containers ^>=0.2.1.0,
@@ -117,7 +117,7 @@ executable  dhall-to-cabal
     build-depends:
         Cabal ^>=2.0,
         base ^>=4.10 || ^>=4.11,
-        dhall ^>=1.13.0,
+        dhall ^>=1.14.0,
         dhall-to-cabal -any,
         optparse-applicative ^>=0.13.2 || ^>=0.14,
         prettyprinter ^>=1.2.0.1,

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -27,7 +27,7 @@ in  let deps =
           , containers =
               majorVersions "containers" [ v "0.5" ]
           , dhall =
-              majorVersions "dhall" [ v "1.13.0" ]
+              majorVersions "dhall" [ v "1.14.0" ]
           , dhall-to-cabal =
               package "dhall-to-cabal" anyVersion
           , filepath =

--- a/dhall.nix
+++ b/dhall.nix
@@ -1,6 +1,6 @@
 { mkDerivation, ansi-terminal, base, bytestring, case-insensitive
 , containers, contravariant, cryptonite, deepseq, directory
-, exceptions, filepath, formatting, haskeline, http-client
+, doctest, exceptions, filepath, formatting, haskeline, http-client
 , http-client-tls, insert-ordered-containers, lens-family-core
 , megaparsec, memory, mtl, optparse-applicative, parsers
 , prettyprinter, prettyprinter-ansi-terminal, repline, scientific
@@ -9,8 +9,8 @@
 }:
 mkDerivation {
   pname = "dhall";
-  version = "1.13.1";
-  sha256 = "c075ac87c2fe5f47573b872126dbb94cabc4441fb532135963741d7edbec50d6";
+  version = "1.14.0";
+  sha256 = "f415842889ca4811f5279714446bad35583829de3c6de04e0d7d3e92f310a836";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
@@ -26,7 +26,7 @@ mkDerivation {
     prettyprinter prettyprinter-ansi-terminal repline text
   ];
   testHaskellDepends = [
-    base deepseq insert-ordered-containers prettyprinter tasty
+    base deepseq doctest insert-ordered-containers prettyprinter tasty
     tasty-hunit text vector
   ];
   description = "A configuration language guaranteed to terminate";

--- a/lib/CabalToDhall.hs
+++ b/lib/CabalToDhall.hs
@@ -63,36 +63,46 @@ import qualified Language.Haskell.Extension as Cabal
 import DhallToCabal ( sortExpr )
 
 
-preludeLocation :: Dhall.Core.Path
+preludeLocation :: Dhall.Core.Import
 preludeLocation =
-  Dhall.Core.Path
-    { Dhall.Core.pathHashed =
-        Dhall.Core.PathHashed
+  Dhall.Core.Import
+    { Dhall.Core.importHashed =
+        Dhall.Core.ImportHashed
           { Dhall.Core.hash =
               Nothing
-          , Dhall.Core.pathType =
+          , Dhall.Core.importType =
               Dhall.Core.URL
-                "https://raw.githubusercontent.com/dhall-lang/dhall-to-cabal/1.0.0/dhall/prelude.dhall"
+                "https://raw.githubusercontent.com"
+                ( Dhall.Core.File
+                   ( Dhall.Core.Directory [ "dhall", "1.0.0", "dhall-to-cabal", "dhall-lang" ] )
+                   "prelude.dhall"
+                )
+                ""
                 Nothing
           }
-    , Dhall.Core.pathMode =
+    , Dhall.Core.importMode =
         Dhall.Core.Code
     }
 
 
-typesLocation :: Dhall.Core.Path
+typesLocation :: Dhall.Core.Import
 typesLocation =
-  Dhall.Core.Path
-    { Dhall.Core.pathHashed =
-        Dhall.Core.PathHashed
+  Dhall.Core.Import
+    { Dhall.Core.importHashed =
+        Dhall.Core.ImportHashed
           { Dhall.Core.hash =
               Nothing
-          , Dhall.Core.pathType =
+          , Dhall.Core.importType =
               Dhall.Core.URL
-                "https://raw.githubusercontent.com/dhall-lang/dhall-to-cabal/1.0.0/dhall/types.dhall"
+                "https://raw.githubusercontent.com"
+                ( Dhall.Core.File
+                   ( Dhall.Core.Directory [ "dhall", "1.0.0", "dhall-to-cabal", "dhall-lang" ] )
+                   "types.dhall"
+                )
+                ""
                 Nothing
           }
-    , Dhall.Core.pathMode =
+    , Dhall.Core.importMode =
         Dhall.Core.Code
     }
 


### PR DESCRIPTION
Extends @quasicomputational's pull request and also regenerates `dhall.nix` for Hydra.