### PR TITLE
cabal-to-dhall: keep the generated imports from GitHub up to date

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -25,6 +25,9 @@
 
 * `cabal-to-dhall` now pretty prints the resulting Dhall.
 
+* The signature of `CabalToDhall.cabalToDhall` has changed: it now takes the location
+  of the `prelude.dhall` and `types.dhall` to import as a parameter.
+
 
 ## 1.0.0.1 -- 2018-03-25
 

--- a/cabal-to-dhall/Main.hs
+++ b/cabal-to-dhall/Main.hs
@@ -13,7 +13,8 @@ import qualified Data.Text.Prettyprint.Doc.Symbols.Unicode as Pretty
 import qualified Options.Applicative as OptParse
 import qualified System.IO
 
-import CabalToDhall ( cabalToDhall )
+import CabalToDhall ( cabalToDhall, DhallLocation ( DhallLocation ) )
+import qualified Paths_dhall_to_cabal as Paths
 
 
 data Command
@@ -55,6 +56,54 @@ main = do
       runCabalToDhall options
 
 
+version :: LazyText.Text
+version = LazyText.pack ( showVersion Paths.version )
+
+
+preludeLocation :: Dhall.Core.Import
+preludeLocation =
+  Dhall.Core.Import
+    { Dhall.Core.importHashed =
+        Dhall.Core.ImportHashed
+          { Dhall.Core.hash =
+              Nothing
+          , Dhall.Core.importType =
+              Dhall.Core.URL
+                "https://raw.githubusercontent.com"
+                ( Dhall.Core.File
+                   ( Dhall.Core.Directory [ "dhall", version, "dhall-to-cabal", "dhall-lang" ] )
+                   "prelude.dhall"
+                )
+                ""
+                Nothing
+          }
+    , Dhall.Core.importMode =
+        Dhall.Core.Code
+    }
+
+
+typesLocation :: Dhall.Core.Import
+typesLocation =
+  Dhall.Core.Import
+    { Dhall.Core.importHashed =
+        Dhall.Core.ImportHashed
+          { Dhall.Core.hash =
+              Nothing
+          , Dhall.Core.importType =
+              Dhall.Core.URL
+                "https://raw.githubusercontent.com"
+                ( Dhall.Core.File
+                   ( Dhall.Core.Directory [ "dhall", version, "dhall-to-cabal", "dhall-lang" ] )
+                   "types.dhall"
+                )
+                ""
+                Nothing
+          }
+    , Dhall.Core.importMode =
+        Dhall.Core.Code
+    }
+
+
 runCabalToDhall :: CabalToDhallOptions -> IO ()
 runCabalToDhall CabalToDhallOptions{ cabalFilePath } = do
   source <-
@@ -66,7 +115,7 @@ runCabalToDhall CabalToDhallOptions{ cabalFilePath } = do
         LazyText.readFile filePath
 
   dhall <-
-    cabalToDhall source
+    cabalToDhall dhallLocation source
 
   Pretty.renderIO
     System.IO.stdout

--- a/cabal-to-dhall/Main.hs
+++ b/cabal-to-dhall/Main.hs
@@ -1,8 +1,10 @@
 {-# language NamedFieldPuns #-}
+{-# language OverloadedStrings #-}
 
 module Main ( main ) where
 
 import Control.Applicative ( (<**>), optional )
+import Data.Version ( showVersion )
 import GHC.Stack
 
 import qualified Data.Text.Lazy as LazyText
@@ -10,6 +12,7 @@ import qualified Data.Text.Lazy.IO as LazyText
 import qualified Data.Text.Prettyprint.Doc as Pretty
 import qualified Data.Text.Prettyprint.Doc.Render.Text as Pretty
 import qualified Data.Text.Prettyprint.Doc.Symbols.Unicode as Pretty
+import qualified Dhall.Core
 import qualified Options.Applicative as OptParse
 import qualified System.IO
 
@@ -106,6 +109,8 @@ typesLocation =
 
 runCabalToDhall :: CabalToDhallOptions -> IO ()
 runCabalToDhall CabalToDhallOptions{ cabalFilePath } = do
+  let dhallLocation = DhallLocation preludeLocation typesLocation
+
   source <-
     case cabalFilePath of
       Nothing ->

--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -140,6 +140,7 @@ executable  cabal-to-dhall
     scope: public
     build-depends:
         base ^>=4.10 || ^>=4.11,
+        dhall ^>=1.14.0,
         dhall-to-cabal -any,
         optparse-applicative ^>=0.13.2 || ^>=0.14,
         prettyprinter ^>=1.2.0.1,
@@ -147,6 +148,8 @@ executable  cabal-to-dhall
     default-language: Haskell2010
     other-extensions: NamedFieldPuns
     hs-source-dirs: cabal-to-dhall
+    other-modules:
+        Paths_dhall_to_cabal
 
 test-suite  golden-tests
     type: exitcode-stdio-1.0

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -215,6 +215,7 @@ in    prelude.utils.GitHub-project
             (   prelude.defaults.Executable
               ⫽ { build-depends =
                     [ deps.base
+                    , deps.dhall
                     , deps.dhall-to-cabal
                     , deps.optparse-applicative
                     , deps.prettyprinter
@@ -226,6 +227,8 @@ in    prelude.utils.GitHub-project
                     "Main.hs"
                 , other-extensions =
                     [ prelude.types.Extensions.NamedFieldPuns True ]
+                , other-modules =
+                    [ "Paths_dhall_to_cabal" ]
                 , default-language =
                     [ prelude.types.Languages.Haskell2010 {=} ] : Optional
                                                                   types.Language

--- a/golden-tests/cabal-to-dhall/conditional-dependencies.dhall
+++ b/golden-tests/cabal-to-dhall/conditional-dependencies.dhall
@@ -1,8 +1,6 @@
-    let prelude =
-          https://raw.githubusercontent.com/dhall-lang/dhall-to-cabal/1.0.0/dhall/prelude.dhall 
+    let prelude = ../../dhall/prelude.dhall 
 
-in  let types =
-          https://raw.githubusercontent.com/dhall-lang/dhall-to-cabal/1.0.0/dhall/types.dhall 
+in  let types = ../../dhall/types.dhall 
 
 in  { author =
         ""

--- a/golden-tests/cabal-to-dhall/gh-36.dhall
+++ b/golden-tests/cabal-to-dhall/gh-36.dhall
@@ -1,8 +1,6 @@
-    let prelude =
-          https://raw.githubusercontent.com/dhall-lang/dhall-to-cabal/1.0.0/dhall/prelude.dhall 
+    let prelude = ../../dhall/prelude.dhall 
 
-in  let types =
-          https://raw.githubusercontent.com/dhall-lang/dhall-to-cabal/1.0.0/dhall/types.dhall 
+in  let types = ../../dhall/types.dhall 
 
 in  { author =
         ""

--- a/golden-tests/cabal-to-dhall/simple.dhall
+++ b/golden-tests/cabal-to-dhall/simple.dhall
@@ -1,8 +1,6 @@
-    let prelude =
-          https://raw.githubusercontent.com/dhall-lang/dhall-to-cabal/1.0.0/dhall/prelude.dhall 
+    let prelude = ../../dhall/prelude.dhall 
 
-in  let types =
-          https://raw.githubusercontent.com/dhall-lang/dhall-to-cabal/1.0.0/dhall/types.dhall 
+in  let types = ../../dhall/types.dhall 
 
 in  { author =
         ""

--- a/lib/CabalToDhall.hs
+++ b/lib/CabalToDhall.hs
@@ -14,7 +14,6 @@ import Control.Monad ( join )
 import Data.Foldable ( foldMap )
 import Data.Functor.Contravariant ( (>$<), Contravariant( contramap ) )
 import Data.Monoid ( First(..) )
-import Data.Version ( showVersion )
 import GHC.Stack
 import Numeric.Natural ( Natural )
 

--- a/lib/CabalToDhall.hs
+++ b/lib/CabalToDhall.hs
@@ -5,12 +5,16 @@
 {-# language OverloadedStrings #-}
 {-# language ViewPatterns #-}
 
-module CabalToDhall ( cabalToDhall ) where
+module CabalToDhall
+  ( cabalToDhall
+  , DhallLocation ( DhallLocation )
+  ) where
 
 import Control.Monad ( join )
 import Data.Foldable ( foldMap )
 import Data.Functor.Contravariant ( (>$<), Contravariant( contramap ) )
 import Data.Monoid ( First(..) )
+import Data.Version ( showVersion )
 import GHC.Stack
 import Numeric.Natural ( Natural )
 
@@ -64,56 +68,18 @@ import DhallToCabal ( sortExpr )
 import DhallToCabal.ConfigTree ( ConfigTree(..) )
 
 
-preludeLocation :: Dhall.Core.Import
-preludeLocation =
-  Dhall.Core.Import
-    { Dhall.Core.importHashed =
-        Dhall.Core.ImportHashed
-          { Dhall.Core.hash =
-              Nothing
-          , Dhall.Core.importType =
-              Dhall.Core.URL
-                "https://raw.githubusercontent.com"
-                ( Dhall.Core.File
-                   ( Dhall.Core.Directory [ "dhall", "1.0.0", "dhall-to-cabal", "dhall-lang" ] )
-                   "prelude.dhall"
-                )
-                ""
-                Nothing
-          }
-    , Dhall.Core.importMode =
-        Dhall.Core.Code
-    }
-
-
-typesLocation :: Dhall.Core.Import
-typesLocation =
-  Dhall.Core.Import
-    { Dhall.Core.importHashed =
-        Dhall.Core.ImportHashed
-          { Dhall.Core.hash =
-              Nothing
-          , Dhall.Core.importType =
-              Dhall.Core.URL
-                "https://raw.githubusercontent.com"
-                ( Dhall.Core.File
-                   ( Dhall.Core.Directory [ "dhall", "1.0.0", "dhall-to-cabal", "dhall-lang" ] )
-                   "types.dhall"
-                )
-                ""
-                Nothing
-          }
-    , Dhall.Core.importMode =
-        Dhall.Core.Code
-    }
-
-
 type DhallExpr =
   Dhall.Core.Expr Dhall.Parser.Src Dhall.TypeCheck.X
 
 
-cabalToDhall :: LazyText.Text -> IO ( Expr.Expr Dhall.Parser.Src Dhall.Core.Import )
-cabalToDhall source =
+data DhallLocation = DhallLocation
+  { preludeLocation :: Dhall.Core.Import
+  , typesLocation :: Dhall.Core.Import
+  }
+
+
+cabalToDhall :: DhallLocation -> LazyText.Text -> IO ( Expr.Expr Dhall.Parser.Src Dhall.Core.Import )
+cabalToDhall dhallLocation source =
   case Cabal.parseGenericPackageDescription ( LazyText.unpack source ) of
     Cabal.ParseFailed e -> do
       putStrLn "Could not parse Cabal file: "
@@ -123,13 +89,12 @@ cabalToDhall source =
     Cabal.ParseOk _warnings genericPackageDescription -> do
       let
         dhall =
-          Expr.Let "prelude" Nothing ( Expr.Embed preludeLocation )
-            $ Expr.Let "types" Nothing ( Expr.Embed typesLocation )
-            $ ( Dhall.TypeCheck.absurd <$>
-                Dhall.embed
-                  genericPackageDescriptionToDhall
-                  genericPackageDescription
-              )
+          Expr.Let "prelude" Nothing ( Expr.Embed ( preludeLocation dhallLocation ) )
+          $ Expr.Let "types" Nothing ( Expr.Embed ( typesLocation dhallLocation ) )
+          $ Dhall.TypeCheck.absurd <$>
+              Dhall.embed
+                genericPackageDescriptionToDhall
+                genericPackageDescription
 
       return dhall
 


### PR DESCRIPTION
This will grab the current version number from Paths_dhall_to_cabal
and then generate the URL to import from from that.

As a knock-on change, to prevent the tests breaking every time the
version is bumped, we now omit the imports altogether from
cabal-to-dhall's tests.