### PR TITLE
WIP: print-type: Refer to the Extension union by import.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -35,6 +35,9 @@
 * `prelude.defaults.Executable` has lost its `main-is` field, as it
   makes little sense to have an executable without it.
 
+* `--print-type` now omits the lengthy definition of `Extension`, instead importing
+  it from the prelude. `--self-contained` is a new switch to disable this behaviour.
+
 
 ## 1.0.0.1 -- 2018-03-25
 

--- a/cabal-to-dhall/Main.hs
+++ b/cabal-to-dhall/Main.hs
@@ -4,7 +4,6 @@
 module Main ( main ) where
 
 import Control.Applicative ( (<**>), optional )
-import Data.Version ( showVersion )
 import GHC.Stack
 
 import qualified Data.ByteString as ByteString
@@ -17,8 +16,8 @@ import qualified Dhall.Core
 import qualified Options.Applicative as OptParse
 import qualified System.IO
 
-import CabalToDhall ( cabalToDhall, DhallLocation ( DhallLocation ) )
-import qualified Paths_dhall_to_cabal as Paths
+import CabalToDhall ( cabalToDhall )
+import DhallLocation ( dhallFromGitHub )
 
 
 data Command
@@ -60,58 +59,8 @@ main = do
       runCabalToDhall options
 
 
-version :: LazyText.Text
-version = LazyText.pack ( showVersion Paths.version )
-
-
-preludeLocation :: Dhall.Core.Import
-preludeLocation =
-  Dhall.Core.Import
-    { Dhall.Core.importHashed =
-        Dhall.Core.ImportHashed
-          { Dhall.Core.hash =
-              Nothing
-          , Dhall.Core.importType =
-              Dhall.Core.URL
-                "https://raw.githubusercontent.com"
-                ( Dhall.Core.File
-                   ( Dhall.Core.Directory [ "dhall", version, "dhall-to-cabal", "dhall-lang" ] )
-                   "prelude.dhall"
-                )
-                ""
-                Nothing
-          }
-    , Dhall.Core.importMode =
-        Dhall.Core.Code
-    }
-
-
-typesLocation :: Dhall.Core.Import
-typesLocation =
-  Dhall.Core.Import
-    { Dhall.Core.importHashed =
-        Dhall.Core.ImportHashed
-          { Dhall.Core.hash =
-              Nothing
-          , Dhall.Core.importType =
-              Dhall.Core.URL
-                "https://raw.githubusercontent.com"
-                ( Dhall.Core.File
-                   ( Dhall.Core.Directory [ "dhall", version, "dhall-to-cabal", "dhall-lang" ] )
-                   "types.dhall"
-                )
-                ""
-                Nothing
-          }
-    , Dhall.Core.importMode =
-        Dhall.Core.Code
-    }
-
-
 runCabalToDhall :: CabalToDhallOptions -> IO ()
 runCabalToDhall CabalToDhallOptions{ cabalFilePath } = do
-  let dhallLocation = DhallLocation preludeLocation typesLocation
-
   source <-
     case cabalFilePath of
       Nothing ->
@@ -121,7 +70,7 @@ runCabalToDhall CabalToDhallOptions{ cabalFilePath } = do
         ByteString.readFile filePath
 
   dhall <-
-    cabalToDhall dhallLocation source
+    cabalToDhall dhallFromGitHub source
 
   Pretty.renderIO
     System.IO.stdout

--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -105,12 +105,14 @@ source-repository head
 library
     exposed-modules:
         DhallToCabal
+        DhallLocation
         CabalToDhall
     hs-source-dirs: lib
     other-modules:
         DhallToCabal.ConfigTree
         DhallToCabal.Diff
         Dhall.Extra
+        Paths_dhall_to_cabal
     default-language: Haskell2010
     other-extensions: ApplicativeDo GADTs GeneralizedNewtypeDeriving
                       LambdaCase OverloadedStrings RecordWildCards TypeApplications
@@ -142,13 +144,12 @@ executable dhall-to-cabal
         insert-ordered-containers ^>=0.2.1.0,
         optparse-applicative ^>=0.13.2 || ^>=0.14,
         prettyprinter ^>=1.2.0.1,
-        text ^>=1.2
+        text ^>=1.2,
+        transformers ^>=0.5.2
 
 executable cabal-to-dhall
     main-is: Main.hs
     hs-source-dirs: cabal-to-dhall
-    other-modules:
-        Paths_dhall_to_cabal
     default-language: Haskell2010
     other-extensions: NamedFieldPuns
     build-depends:

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -173,7 +173,7 @@ in    prelude.utils.GitHub-project
                     prelude.defaults.CompilerOptions
                   ⫽ { GHC = [ "-Wall", "-fno-warn-name-shadowing" ] }
               , exposed-modules =
-                  [ "DhallToCabal", "CabalToDhall" ]
+                  [ "DhallToCabal", "DhallLocation", "CabalToDhall" ]
               , hs-source-dirs =
                   [ "lib" ]
               , other-extensions =
@@ -189,6 +189,7 @@ in    prelude.utils.GitHub-project
                   [ "DhallToCabal.ConfigTree"
                   , "DhallToCabal.Diff"
                   , "Dhall.Extra"
+                  , "Paths_dhall_to_cabal"
                   ]
               , default-language =
                   [ prelude.types.Languages.Haskell2010 {=} ] : Optional
@@ -208,6 +209,7 @@ in    prelude.utils.GitHub-project
                     , deps.optparse-applicative
                     , deps.prettyprinter
                     , deps.text
+                    , deps.transformers
                     ]
                 , hs-source-dirs =
                     [ "exe" ]
@@ -238,8 +240,6 @@ in    prelude.utils.GitHub-project
                     "Main.hs"
                 , other-extensions =
                     [ prelude.types.Extensions.NamedFieldPuns True ]
-                , other-modules =
-                    [ "Paths_dhall_to_cabal" ]
                 , default-language =
                     [ prelude.types.Languages.Haskell2010 {=} ] : Optional
                                                                   types.Language

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -91,6 +91,8 @@ isCandidateSubrecord _ = False
 
 shouldBeImported :: KnownType -> Bool
 shouldBeImported Extension = True
+shouldBeImported LicenseId = True
+shouldBeImported LicenseExceptionId = True
 shouldBeImported _ = False
 
 

--- a/golden-tests/GoldenTests.hs
+++ b/golden-tests/GoldenTests.hs
@@ -23,7 +23,8 @@ import qualified Distribution.PackageDescription.PrettyPrint as Cabal
 import qualified Distribution.PackageDescription as Cabal
 import qualified Distribution.Verbosity as Cabal
 
-import CabalToDhall ( cabalToDhall, DhallLocation ( DhallLocation ) )
+import CabalToDhall ( cabalToDhall )
+import DhallLocation ( DhallLocation ( DhallLocation ) )
 import DhallToCabal ( dhallToCabal )
 
 

--- a/lib/CabalToDhall.hs
+++ b/lib/CabalToDhall.hs
@@ -7,7 +7,6 @@
 
 module CabalToDhall
   ( cabalToDhall
-  , DhallLocation ( DhallLocation )
   ) where
 
 import Control.Monad ( join )
@@ -66,18 +65,13 @@ import qualified Distribution.Types.UnqualComponentName as Cabal
 import qualified Distribution.Version as Cabal
 import qualified Language.Haskell.Extension as Cabal
 
+import DhallLocation ( DhallLocation(..) )
 import DhallToCabal ( sortExpr )
 import DhallToCabal.ConfigTree ( ConfigTree(..) )
 
 
 type DhallExpr =
   Dhall.Core.Expr Dhall.Parser.Src Dhall.TypeCheck.X
-
-
-data DhallLocation = DhallLocation
-  { preludeLocation :: Dhall.Core.Import
-  , typesLocation :: Dhall.Core.Import
-  }
 
 
 cabalToDhall :: DhallLocation -> ByteString.ByteString -> IO ( Expr.Expr Dhall.Parser.Src Dhall.Core.Import )

--- a/lib/DhallLocation.hs
+++ b/lib/DhallLocation.hs
@@ -1,0 +1,69 @@
+{-# language OverloadedStrings #-}
+
+module DhallLocation
+  ( DhallLocation(..)
+  , dhallFromGitHub
+  )
+  where
+
+import Data.Version ( showVersion )
+
+import qualified Data.Text.Lazy as LazyText
+import qualified Dhall.Core
+
+import qualified Paths_dhall_to_cabal as Paths
+
+
+data DhallLocation = DhallLocation
+  { preludeLocation :: Dhall.Core.Import
+  , typesLocation :: Dhall.Core.Import
+  }
+
+
+version :: LazyText.Text
+version = LazyText.pack ( showVersion Paths.version )
+
+
+dhallFromGitHub :: DhallLocation
+dhallFromGitHub =
+  DhallLocation
+    { preludeLocation =
+        Dhall.Core.Import
+          { Dhall.Core.importHashed =
+              Dhall.Core.ImportHashed
+                { Dhall.Core.hash =
+                    Nothing
+                , Dhall.Core.importType =
+                    Dhall.Core.URL
+                      "https://raw.githubusercontent.com"
+                      ( Dhall.Core.File
+                         ( Dhall.Core.Directory [ "dhall", version, "dhall-to-cabal", "dhall-lang" ] )
+                         "prelude.dhall"
+                      )
+                      ""
+                      Nothing
+                }
+          , Dhall.Core.importMode =
+              Dhall.Core.Code
+          }
+
+    , typesLocation =
+        Dhall.Core.Import
+          { Dhall.Core.importHashed =
+              Dhall.Core.ImportHashed
+                { Dhall.Core.hash =
+                    Nothing
+                , Dhall.Core.importType =
+                    Dhall.Core.URL
+                      "https://raw.githubusercontent.com"
+                      ( Dhall.Core.File
+                         ( Dhall.Core.Directory [ "dhall", version, "dhall-to-cabal", "dhall-lang" ] )
+                         "types.dhall"
+                      )
+                      ""
+                      Nothing
+                }
+          , Dhall.Core.importMode =
+              Dhall.Core.Code
+          }
+    }


### PR DESCRIPTION
`Extension` is fairly large and it's not particularly illuminating to
scroll through, so refer to it by an import unless it's the specific
type that the user has asked for.

A new option, `--self-contained`, disables the reference-by-import
and, as the name suggests, makes `--print-type` output fully
self-contained.

Closes #69.

Not quite in a mergeable state yet; best to wait for #66 and then refactor the `typesLocation` boilerplate into a central location, and in the meantime the code wants a little tidying.