### PR TITLE
 Add a version of Github-project with the source repo data parameterized

### DIFF
--- a/dhall/GitHub-project.dhall
+++ b/dhall/GitHub-project.dhall
@@ -1,26 +1,5 @@
-    let GitHubProject : Type = { owner : Text, repo : Text }
-
-in  let gitHubProject =
-            λ(github : GitHubProject)
-          →     let gitHubRoot =
-                      "https://github.com/${github.owner}/${github.repo}"
-            
-            in    ./defaults/Package.dhall 
-                ⫽ { name =
-                      github.repo
-                  , bug-reports =
-                      "${gitHubRoot}/issues"
-                  , homepage =
-                      gitHubRoot
-                  , source-repos =
-                      [   ./defaults/SourceRepo.dhall 
-                        ⫽ { location =
-                              [ gitHubRoot ] : Optional Text
-                          , type =
-                              [ (constructors ./types/RepoType.dhall ).Git {=}
-                              ] : Optional ./types/RepoType.dhall 
-                          }
-                      ]
-                  }
-
+    let gitHubWithSourceRepo =
+            ./GitHubWithSourceRepo-project.dhall
+in  let gitHubProject = 
+            gitHubWithSourceRepo ./defaults/SourceRepo.dhall
 in  gitHubProject

--- a/dhall/GitHubWithSourceRepo-project.dhall
+++ b/dhall/GitHubWithSourceRepo-project.dhall
@@ -1,0 +1,26 @@
+    let GitHubProject : Type = { owner : Text, repo : Text }
+in  let gitHubWithSourceRepoProject =
+            λ(repoData : ./types/SourceRepo.dhall )
+          → λ(github : GitHubProject)
+          →     let gitHubRoot =
+                      "https://github.com/${github.owner}/${github.repo}"
+            
+            in    ./defaults/Package.dhall 
+                ⫽ { name =
+                      github.repo
+                  , bug-reports =
+                      "${gitHubRoot}/issues"
+                  , homepage =
+                      gitHubRoot
+                  , source-repos =
+                      [   repoData
+                        ⫽ { location =
+                              [ gitHubRoot ] : Optional Text
+                          , type =
+                              [ (constructors ./types/RepoType.dhall ).Git {=}
+                              ] : Optional ./types/RepoType.dhall 
+                          }
+                      ]
+                  }
+
+in  gitHubWithSourceRepoProject

--- a/dhall/prelude.dhall
+++ b/dhall/prelude.dhall
@@ -107,7 +107,9 @@
         
         in  majorVersions
     , GitHub-project =
-        ./GitHub-project.dhall 
+        ./GitHub-project.dhall
+    , GitHubWithSourceRepo-project =
+        ./GitHubWithSourceRepo-project.dhall
     }
 , unconditional =
     ./unconditional.dhall 

--- a/golden-tests/dhall-to-cabal/github-source-repo.cabal
+++ b/golden-tests/dhall-to-cabal/github-source-repo.cabal
@@ -1,0 +1,16 @@
+name: repo
+version: 1.0.0
+cabal-version: 2.0
+build-type: Simple
+license: UnspecifiedLicense
+homepage: https://github.com/owner/repo
+bug-reports: https://github.com/owner/repo/issues
+
+source-repository this
+    type: git
+    location: https://github.com/owner/repo
+    tag: 1.0.0
+
+executable  foo
+
+

--- a/golden-tests/dhall-to-cabal/github-source-repo.cabal
+++ b/golden-tests/dhall-to-cabal/github-source-repo.cabal
@@ -12,5 +12,5 @@ source-repository this
     tag: 1.0.0
 
 executable  foo
-
+    scope: public
 

--- a/golden-tests/dhall-to-cabal/github-source-repo.dhall
+++ b/golden-tests/dhall-to-cabal/github-source-repo.dhall
@@ -1,0 +1,25 @@
+   let prelude = ./dhall/prelude.dhall
+
+in let types = ./dhall/types.dhall
+
+in let RepoKind = constructors types.RepoKind
+
+in let GitHub-project = prelude.utils.GitHubWithSourceRepo-project
+                        ( prelude.defaults.SourceRepo
+                       // { tag = ["1.0.0"] : Optional Text
+                          , kind = RepoKind.RepoThis {=}
+                          }
+                         )
+                         { owner = "owner" , repo = "repo" }
+in  GitHub-project
+ // { version =
+        prelude.v "1.0.0"
+    , executables =
+      [ { name =
+            "foo"
+        , executable =
+            λ(config : ./dhall/types/Config.dhall)
+          → ./dhall/defaults/Executable.dhall
+        }
+      ]
+    }


### PR DESCRIPTION
To make easy set other values (kind, tag, etc) of the `source-repository` section (see new test case)