### PR TITLE
Omit main-is from the default Executable.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -28,6 +28,9 @@
 * The signature of `CabalToDhall.cabalToDhall` has changed: it now takes the location
   of the `prelude.dhall` and `types.dhall` to import as a parameter.
 
+* `prelude.defaults.Executable` has lost its `main-is` field, as it
+  makes little sense to have an executable without it.
+
 
 ## 1.0.0.1 -- 2018-03-25
 

--- a/dhall/defaults/Executable.dhall
+++ b/dhall/defaults/Executable.dhall
@@ -1,2 +1,2 @@
   ./BuildInfo.dhall 
-⫽ { main-is = "", scope = (constructors ../types/Scope.dhall ).Public {=} }
+⫽ { scope = (constructors ../types/Scope.dhall ).Public {=} }

--- a/golden-tests/dhall-to-cabal/empty-package.cabal
+++ b/golden-tests/dhall-to-cabal/empty-package.cabal
@@ -5,5 +5,6 @@ build-type: Simple
 license: UnspecifiedLicense
 
 executable  foo
+    main-is: Main.hs
     scope: public
 

--- a/golden-tests/dhall-to-cabal/empty-package.dhall
+++ b/golden-tests/dhall-to-cabal/empty-package.dhall
@@ -9,6 +9,7 @@
         , executable =
             λ(config : ./dhall/types/Config.dhall)
           → ./dhall/defaults/Executable.dhall
+          ⫽ { main-is = "Main.hs" }
         }
       ]
   }


### PR DESCRIPTION
Much like #46, this is a field that it is not sensible to do without.