### PR TITLE
Also add Paths_dhall_to_cabal to autogen-modules

### DIFF
--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -113,6 +113,8 @@ library
         DhallToCabal.Diff
         Dhall.Extra
         Paths_dhall_to_cabal
+    autogen-modules:
+        Paths_dhall_to_cabal
     default-language: Haskell2010
     other-extensions: ApplicativeDo GADTs GeneralizedNewtypeDeriving
                       LambdaCase OverloadedStrings RecordWildCards TypeApplications

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -172,6 +172,8 @@ in    prelude.utils.GitHub-project
               , compiler-options =
                     prelude.defaults.CompilerOptions
                   ⫽ { GHC = [ "-Wall", "-fno-warn-name-shadowing" ] }
+              , autogen-modules =
+                  [ "Paths_dhall_to_cabal" ]
               , exposed-modules =
                   [ "DhallToCabal", "DhallLocation", "CabalToDhall" ]
               , hs-source-dirs =


### PR DESCRIPTION
Hackage complains:

> Packages using 'cabal-version: 2.0' and the autogenerated module Paths_* must
> include it also on the 'autogen-modules' field besides 'exposed-modules' and
> 'other-modules'. This specifies that the module does not come with the package
> and is generated on setup. Modules built with a custom Setup.hs script also go
> here to ensure that commands like sdist don't fail.