### PR TITLE
Don't double up on other-modules in defaults/Library.dhall

### DIFF
--- a/dhall/defaults/Library.dhall
+++ b/dhall/defaults/Library.dhall
@@ -1,8 +1,6 @@
   ./BuildInfo.dhall 
 ⫽ { exposed-modules =
       [] : List Text
-  , other-modules =
-      [] : List Text
   , reexported-modules =
       [] : List
            { name : Text, original : { name : Text, package : Optional Text } }


### PR DESCRIPTION
defaults/BuildInfo.dhall already includes an other-modules field.