### PR TITLE
Refactor license in CabalToDhall

### DIFF
--- a/golden-tests/cabal-to-dhall/SPDX.dhall
+++ b/golden-tests/cabal-to-dhall/SPDX.dhall
@@ -43,60 +43,32 @@ in  { author =
     , library =
         [] : Optional (types.Config → types.Library)
     , license =
-        < SPDX =
-            prelude.SPDX.and
-            ( prelude.SPDX.or
-              ( prelude.SPDX.license
-                (prelude.types.LicenseId.AGPL_3_0_or_later {=})
-                ( [ prelude.types.LicenseExceptionId.Classpath_exception_2_0 {=}
-                  ] : Optional types.LicenseExceptionId
-                )
-              )
-              ( prelude.SPDX.licenseVersionOrLater
-                (prelude.types.LicenseId.Apache_2_0 {=})
-                ([] : Optional types.LicenseExceptionId)
+        prelude.types.Licenses.SPDX
+        ( prelude.SPDX.and
+          ( prelude.SPDX.or
+            ( prelude.SPDX.license
+              (prelude.types.LicenseId.AGPL_3_0_or_later {=})
+              ( [ prelude.types.LicenseExceptionId.Classpath_exception_2_0 {=}
+                ] : Optional types.LicenseExceptionId
               )
             )
-            ( prelude.SPDX.or
-              ( prelude.SPDX.ref
-                "MyFancyLicense"
-                ([] : Optional types.LicenseExceptionId)
-              )
-              ( prelude.SPDX.refWithFile
-                "MyFancierLicense"
-                "LICENSE.txt"
-                ([] : Optional types.LicenseExceptionId)
-              )
+            ( prelude.SPDX.licenseVersionOrLater
+              (prelude.types.LicenseId.Apache_2_0 {=})
+              ([] : Optional types.LicenseExceptionId)
             )
-        | GPL :
-            Optional types.Version
-        | AGPL :
-            Optional types.Version
-        | LGPL :
-            Optional types.Version
-        | BSD2 :
-            {}
-        | BSD3 :
-            {}
-        | BSD4 :
-            {}
-        | MIT :
-            {}
-        | ISC :
-            {}
-        | MPL :
-            types.Version
-        | Apache :
-            Optional types.Version
-        | PublicDomain :
-            {}
-        | AllRightsReserved :
-            {}
-        | Unspecified :
-            {}
-        | Other :
-            {}
-        >
+          )
+          ( prelude.SPDX.or
+            ( prelude.SPDX.ref
+              "MyFancyLicense"
+              ([] : Optional types.LicenseExceptionId)
+            )
+            ( prelude.SPDX.refWithFile
+              "MyFancierLicense"
+              "LICENSE.txt"
+              ([] : Optional types.LicenseExceptionId)
+            )
+          )
+        )
     , license-files =
         [] : List Text
     , maintainer =

--- a/golden-tests/cabal-to-dhall/conditional-dependencies.dhall
+++ b/golden-tests/cabal-to-dhall/conditional-dependencies.dhall
@@ -510,37 +510,7 @@ in  { author =
                   }
         ] : Optional (types.Config → types.Library)
     , license =
-        < Unspecified =
-            {=}
-        | GPL :
-            Optional types.Version
-        | AGPL :
-            Optional types.Version
-        | LGPL :
-            Optional types.Version
-        | BSD2 :
-            {}
-        | BSD3 :
-            {}
-        | BSD4 :
-            {}
-        | MIT :
-            {}
-        | ISC :
-            {}
-        | MPL :
-            types.Version
-        | Apache :
-            Optional types.Version
-        | PublicDomain :
-            {}
-        | AllRightsReserved :
-            {}
-        | Other :
-            {}
-        | SPDX :
-            types.SPDX
-        >
+        prelude.types.Licenses.Unspecified {=}
     , license-files =
         [] : List Text
     , maintainer =

--- a/golden-tests/cabal-to-dhall/gh-36.dhall
+++ b/golden-tests/cabal-to-dhall/gh-36.dhall
@@ -1974,37 +1974,7 @@ in  { author =
                   }
         ] : Optional (types.Config → types.Library)
     , license =
-        < AllRightsReserved =
-            {=}
-        | GPL :
-            Optional types.Version
-        | AGPL :
-            Optional types.Version
-        | LGPL :
-            Optional types.Version
-        | BSD2 :
-            {}
-        | BSD3 :
-            {}
-        | BSD4 :
-            {}
-        | MIT :
-            {}
-        | ISC :
-            {}
-        | MPL :
-            types.Version
-        | Apache :
-            Optional types.Version
-        | PublicDomain :
-            {}
-        | Unspecified :
-            {}
-        | Other :
-            {}
-        | SPDX :
-            types.SPDX
-        >
+        prelude.types.Licenses.AllRightsReserved {=}
     , license-files =
         [] : List Text
     , maintainer =

--- a/golden-tests/cabal-to-dhall/otheros.dhall
+++ b/golden-tests/cabal-to-dhall/otheros.dhall
@@ -243,37 +243,7 @@ in  { author =
                   }
         ] : Optional (types.Config → types.Library)
     , license =
-        < AllRightsReserved =
-            {=}
-        | GPL :
-            Optional types.Version
-        | AGPL :
-            Optional types.Version
-        | LGPL :
-            Optional types.Version
-        | BSD2 :
-            {}
-        | BSD3 :
-            {}
-        | BSD4 :
-            {}
-        | MIT :
-            {}
-        | ISC :
-            {}
-        | MPL :
-            types.Version
-        | Apache :
-            Optional types.Version
-        | PublicDomain :
-            {}
-        | Unspecified :
-            {}
-        | Other :
-            {}
-        | SPDX :
-            types.SPDX
-        >
+        prelude.types.Licenses.AllRightsReserved {=}
     , license-files =
         [] : List Text
     , maintainer =

--- a/golden-tests/cabal-to-dhall/simple.dhall
+++ b/golden-tests/cabal-to-dhall/simple.dhall
@@ -43,37 +43,7 @@ in  { author =
     , library =
         [] : Optional (types.Config → types.Library)
     , license =
-        < AllRightsReserved =
-            {=}
-        | GPL :
-            Optional types.Version
-        | AGPL :
-            Optional types.Version
-        | LGPL :
-            Optional types.Version
-        | BSD2 :
-            {}
-        | BSD3 :
-            {}
-        | BSD4 :
-            {}
-        | MIT :
-            {}
-        | ISC :
-            {}
-        | MPL :
-            types.Version
-        | Apache :
-            Optional types.Version
-        | PublicDomain :
-            {}
-        | Unspecified :
-            {}
-        | Other :
-            {}
-        | SPDX :
-            types.SPDX
-        >
+        prelude.types.Licenses.AllRightsReserved {=}
     , license-files =
         [] : List Text
     , maintainer =


### PR DESCRIPTION
This removes a use of runUnion (#84) and produces much friendlier
output.

Originally part of #83, but this is a separable change that we want
anyway, no matter which direction that PR goes.