### PR TITLE
CabalToDhall: make cabalToDhall a pure function.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,10 @@
 
 * `dhall-to-cabal` and `cabal-to-dhall` now respond to `--version`.
 
+* `CabalToDhall.cabalToDhall` is now a pure function that accepts a
+  `GenericPackageDescription`. A new convenience function has been
+  added to `CabalToDhall`, `parseGenericPackageDescriptionThrows`.
+
 ## 1.1.0.0 -- 2018-06-03
 
 ### Breaking Changes

--- a/cabal-to-dhall/Main.hs
+++ b/cabal-to-dhall/Main.hs
@@ -13,7 +13,7 @@ import qualified Data.Text.Prettyprint.Doc.Render.Text as Pretty
 import qualified Options.Applicative as OptParse
 import qualified System.IO
 
-import CabalToDhall ( cabalToDhall )
+import CabalToDhall ( cabalToDhall, parseGenericPackageDescriptionThrows )
 import DhallLocation ( dhallFromGitHub )
 import Paths_dhall_to_cabal ( version )
 
@@ -85,8 +85,8 @@ runCabalToDhall CabalToDhallOptions{ cabalFilePath } = do
       Just filePath ->
         ByteString.readFile filePath
 
-  dhall <-
-    cabalToDhall dhallFromGitHub source
+  dhall <- cabalToDhall dhallFromGitHub <$>
+    parseGenericPackageDescriptionThrows source
 
   Pretty.renderIO
     System.IO.stdout

--- a/golden-tests/GoldenTests.hs
+++ b/golden-tests/GoldenTests.hs
@@ -20,7 +20,7 @@ import qualified Distribution.PackageDescription.Parsec as Cabal
 import qualified Distribution.PackageDescription.PrettyPrint as Cabal
 import qualified Distribution.Verbosity as Cabal
 
-import CabalToDhall ( cabalToDhall )
+import CabalToDhall ( cabalToDhall, parseGenericPackageDescriptionThrows )
 import DhallLocation ( DhallLocation ( DhallLocation ) )
 import DhallToCabal ( dhallToCabal )
 
@@ -111,9 +111,10 @@ goldenTests = do
              ( takeBaseName cabalFile )
              ( \ ref new -> [ "diff", "-u", ref, new ] )
              dhallFile
-             ( BS.readFile cabalFile >>= cabalToDhall dhallLocation
+             ( BS.readFile cabalFile >>= parseGenericPackageDescriptionThrows
                  & fmap ( LazyText.encodeUtf8 . Pretty.renderLazy
                         . Pretty.layoutSmart layoutOpts . Pretty.pretty
+                        . cabalToDhall dhallLocation
                         )
              )
          | cabalFile <- cabalFiles


### PR DESCRIPTION
Also expose parseGenericPackageDescriptionThrows, a new convenience
function.

This is useful because any external consumers of the CabalToDhall API
will likely have a GenericPackageDescription on hand; rather than
serialising it only to pass it in and have it re-parsed, skipping the
indirection makes sense.