### PR TITLE
Map between SPDX.NONE and AllRightsReserved depending on cabal-version

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,11 @@
   Code that only imports `prelude.dhall` and `types.dhall` is
   unaffected by this change.
 
+* `prelude.defaults.Package.license` is now `AllRightsReserved`.
+
+* `dhall-to-cabal` now maps `AllRightsReserved` to `SPDX.NONE` when
+  `cabal-version` is at least 2.2.
+
 ## 1.1.0.0 -- 2018-06-03
 
 ### Breaking Changes

--- a/dhall/defaults/Package.dhall
+++ b/dhall/defaults/Package.dhall
@@ -51,7 +51,7 @@
 , library =
     [] : Optional (../types/Guarded.dhall  ../types/Library.dhall )
 , license =
-    (constructors ../types/License.dhall ).Unspecified {=}
+    (constructors ../types/License.dhall ).AllRightsReserved {=}
 , license-files =
     [] : List Text
 , maintainer =

--- a/golden-tests/cabal-to-dhall/default-license-2.2.cabal
+++ b/golden-tests/cabal-to-dhall/default-license-2.2.cabal
@@ -1,0 +1,3 @@
+cabal-version: 2.2
+name: test
+version: 1.0

--- a/golden-tests/cabal-to-dhall/default-license-2.2.dhall
+++ b/golden-tests/cabal-to-dhall/default-license-2.2.dhall
@@ -1,0 +1,86 @@
+    let prelude = ../../dhall/prelude.dhall 
+
+in  let types = ../../dhall/types.dhall 
+
+in  { author =
+        ""
+    , benchmarks =
+        [] : List { benchmark : types.Config → types.Benchmark, name : Text }
+    , bug-reports =
+        ""
+    , build-type =
+        [] : Optional types.BuildType
+    , cabal-version =
+        prelude.v "2.2"
+    , category =
+        ""
+    , copyright =
+        ""
+    , custom-setup =
+        [] : Optional types.CustomSetup
+    , data-dir =
+        ""
+    , data-files =
+        [] : List Text
+    , description =
+        ""
+    , executables =
+        [] : List { executable : types.Config → types.Executable, name : Text }
+    , extra-doc-files =
+        [] : List Text
+    , extra-source-files =
+        [] : List Text
+    , extra-tmp-files =
+        [] : List Text
+    , flags =
+        [] : List
+             { default : Bool, description : Text, manual : Bool, name : Text }
+    , foreign-libraries =
+        [] : List
+             { foreign-lib : types.Config → types.ForeignLibrary, name : Text }
+    , homepage =
+        ""
+    , library =
+        [] : Optional (types.Config → types.Library)
+    , license =
+        prelude.types.Licenses.AllRightsReserved {=}
+    , license-files =
+        [] : List Text
+    , maintainer =
+        ""
+    , name =
+        "test"
+    , package-url =
+        ""
+    , source-repos =
+        [] : List
+             { branch :
+                 Optional Text
+             , kind :
+                 types.RepoKind
+             , location :
+                 Optional Text
+             , module :
+                 Optional Text
+             , subdir :
+                 Optional Text
+             , tag :
+                 Optional Text
+             , type :
+                 Optional types.RepoType
+             }
+    , stability =
+        ""
+    , sub-libraries =
+        [] : List { library : types.Config → types.Library, name : Text }
+    , synopsis =
+        ""
+    , test-suites =
+        [] : List { name : Text, test-suite : types.Config → types.TestSuite }
+    , tested-with =
+        [] : List { compiler : types.Compiler, version : types.VersionRange }
+    , version =
+        prelude.v "1.0"
+    , x-fields =
+        [] : List { _1 : Text, _2 : Text }
+    }

--- a/golden-tests/dhall-to-cabal/allrightsreserved-2.0.cabal
+++ b/golden-tests/dhall-to-cabal/allrightsreserved-2.0.cabal
@@ -1,8 +1,7 @@
 cabal-version: 2.0
-name: Name
-version: 1
+name: foo
+version: 0
 license: AllRightsReserved
 build-type: Simple
 
-executable foo
-    main-is: Main.hs
+library

--- a/golden-tests/dhall-to-cabal/allrightsreserved-2.0.dhall
+++ b/golden-tests/dhall-to-cabal/allrightsreserved-2.0.dhall
@@ -1,0 +1,9 @@
+   let prelude = ./dhall/prelude.dhall
+in let types = ./dhall/types.dhall
+in   prelude.defaults.Package
+  // { name = "foo"
+     , version = prelude.v "0"
+     , cabal-version = prelude.v "2.0"
+     , license = prelude.types.Licenses.AllRightsReserved {=}
+     , library = prelude.unconditional.library prelude.defaults.Library
+     }

--- a/golden-tests/dhall-to-cabal/allrightsreserved-2.2.cabal
+++ b/golden-tests/dhall-to-cabal/allrightsreserved-2.2.cabal
@@ -1,0 +1,7 @@
+cabal-version: 2.2
+name: foo
+version: 0
+build-type: Simple
+license: NONE
+
+library

--- a/golden-tests/dhall-to-cabal/allrightsreserved-2.2.dhall
+++ b/golden-tests/dhall-to-cabal/allrightsreserved-2.2.dhall
@@ -1,0 +1,9 @@
+   let prelude = ./dhall/prelude.dhall
+in let types = ./dhall/types.dhall
+in   prelude.defaults.Package
+  // { name = "foo"
+     , version = prelude.v "0"
+     , cabal-version = prelude.v "2.2"
+     , license = prelude.types.Licenses.AllRightsReserved {=}
+     , library = prelude.unconditional.library prelude.defaults.Library
+     }

--- a/golden-tests/dhall-to-cabal/compiler-options-order.cabal
+++ b/golden-tests/dhall-to-cabal/compiler-options-order.cabal
@@ -1,10 +1,13 @@
+cabal-version: 2.0
 name: Name
 version: 1
-cabal-version: 2.0
+license: AllRightsReserved
 build-type: Simple
-license: UnspecifiedLicense
 
 library
+    exposed-modules:
+        Foo
+        Bar
     
     if impl(ghc >=8.2)
         
@@ -18,8 +21,3 @@ library
             ghc-options: A C E F
         else
             ghc-options: A F
-    exposed-modules:
-        Foo
-        Bar
-
-

--- a/golden-tests/dhall-to-cabal/conditional-dependencies.cabal
+++ b/golden-tests/dhall-to-cabal/conditional-dependencies.cabal
@@ -1,10 +1,12 @@
+cabal-version: 2.0
 name: Name
 version: 1
-cabal-version: 2.0
+license: AllRightsReserved
 build-type: Simple
-license: UnspecifiedLicense
 
 library
+    build-depends:
+        A -any
     
     if impl(ghc >=8.2)
         build-depends:
@@ -15,7 +17,3 @@ library
         build-depends:
             C -any
     else
-    build-depends:
-        A -any
-
-

--- a/golden-tests/dhall-to-cabal/default-license-2.2.cabal
+++ b/golden-tests/dhall-to-cabal/default-license-2.2.cabal
@@ -1,0 +1,7 @@
+cabal-version: 2.2
+name: foo
+version: 0
+license: NONE
+build-type: Simple
+
+library

--- a/golden-tests/dhall-to-cabal/default-license-2.2.dhall
+++ b/golden-tests/dhall-to-cabal/default-license-2.2.dhall
@@ -1,0 +1,8 @@
+   let prelude = ./dhall/prelude.dhall
+in let types = ./dhall/types.dhall
+in   prelude.defaults.Package
+  // { name = "foo"
+     , version = prelude.v "0"
+     , cabal-version = prelude.v "2.2"
+     , library = prelude.unconditional.library prelude.defaults.Library
+     }

--- a/golden-tests/dhall-to-cabal/gh-53.cabal
+++ b/golden-tests/dhall-to-cabal/gh-53.cabal
@@ -1,8 +1,8 @@
+cabal-version: 2.0
 name: wai-servlet
 version: 0.1.5.0
-cabal-version: 2.0
+license: AllRightsReserved
 build-type: Simple
-license: UnspecifiedLicense
 
 flag wai-servlet-debug
     description:
@@ -19,5 +19,3 @@ library
     if flag(wai-servlet-debug)
         cpp-options: -DWAI_SERVLET_DEBUG
     else
-
-

--- a/golden-tests/dhall-to-cabal/gh-55.cabal
+++ b/golden-tests/dhall-to-cabal/gh-55.cabal
@@ -1,10 +1,12 @@
+cabal-version: 2.0
 name: Name
 version: 1
-cabal-version: 2.0
+license: AllRightsReserved
 build-type: Simple
-license: UnspecifiedLicense
 
 library
+    exposed-modules:
+        Module1
     
     if impl(ghc >=7.1.3)
         exposed-modules:
@@ -13,7 +15,3 @@ library
         other-modules:
             OtherModule
     else
-    exposed-modules:
-        Module1
-
-

--- a/golden-tests/dhall-to-cabal/map-source-repo.cabal
+++ b/golden-tests/dhall-to-cabal/map-source-repo.cabal
@@ -1,17 +1,15 @@
+cabal-version: 2.0
 name: repo
 version: 1.0.0
-cabal-version: 2.0
-build-type: Simple
-license: UnspecifiedLicense
+license: AllRightsReserved
 homepage: https://github.com/owner/repo
 bug-reports: https://github.com/owner/repo/issues
+build-type: Simple
 
 source-repository this
     type: git
     location: https://github.com/owner/repo
     tag: 1.0.0
 
-executable  foo
+executable foo
     main-is: Main.hs
-    scope: public
-    

--- a/golden-tests/dhall-to-cabal/nested-conditions.cabal
+++ b/golden-tests/dhall-to-cabal/nested-conditions.cabal
@@ -1,15 +1,16 @@
+cabal-version: 2.0
 name: foo
 version: 0
-cabal-version: 2.0
+license: AllRightsReserved
 build-type: Simple
-license: UnspecifiedLicense
 
 library
     
     if impl(ghc >=8.2)
         
         if impl(ghc >=8.4)
-            ghc-options: -Weverything -Wno-redundant-constraints -Wno-missing-export-lists
+            ghc-options: -Weverything -Wno-redundant-constraints
+                         -Wno-missing-export-lists
         else
             ghc-options: -Weverything -Wno-redundant-constraints
     else
@@ -18,5 +19,3 @@ library
             ghc-options: -Weverything -Wno-missing-export-lists
         else
             ghc-options: -Weverything
-
-

--- a/lib/CabalToDhall.hs
+++ b/lib/CabalToDhall.hs
@@ -266,6 +266,8 @@ licenseToDhall =
             license "PublicDomain" ( Expr.RecordLit mempty )
           Right Cabal.AllRightsReserved ->
             license "AllRightsReserved" ( Expr.RecordLit mempty )
+          -- Note: SPDX.NONE is what Cabal reports for a file without
+          -- a 'license' field, even for pre-2.2 spec versions.
           Left SPDX.NONE ->
             license "AllRightsReserved" ( Expr.RecordLit mempty )
           Right Cabal.UnspecifiedLicense ->


### PR DESCRIPTION
Cabal always reports a `.cabal` file missing the `license` field as
having a license of SPDX.NONE, even for `cabal-version: 2.0`.