### PR TITLE
Have the two default sources agree on the default cabal-version

### DIFF
--- a/golden-tests/cabal-to-dhall/SPDX.dhall
+++ b/golden-tests/cabal-to-dhall/SPDX.dhall
@@ -7,8 +7,6 @@ in    prelude.defaults.Package
           "foo"
       , version =
           prelude.v "0"
-      , cabal-version =
-          prelude.v "2.2"
       , license =
           prelude.types.Licenses.SPDX
           ( prelude.SPDX.and

--- a/golden-tests/cabal-to-dhall/benchmark.dhall
+++ b/golden-tests/cabal-to-dhall/benchmark.dhall
@@ -21,4 +21,6 @@ in    prelude.defaults.Package
                 "fancy-benchmark"
             }
           ]
+      , cabal-version =
+          prelude.v "2.0"
       }

--- a/golden-tests/cabal-to-dhall/conditional-dependencies.dhall
+++ b/golden-tests/cabal-to-dhall/conditional-dependencies.dhall
@@ -7,6 +7,8 @@ in    prelude.defaults.Package
           "Name"
       , version =
           prelude.v "1"
+      , cabal-version =
+          prelude.v "2.0"
       , library =
           [   λ(config : types.Config)
             →       if config.impl

--- a/golden-tests/cabal-to-dhall/default-license-2.2.dhall
+++ b/golden-tests/cabal-to-dhall/default-license-2.2.dhall
@@ -2,11 +2,4 @@
 
 in  let types = ./../../dhall/types.dhall
 
-in    prelude.defaults.Package
-    ⫽ { name =
-          "test"
-      , version =
-          prelude.v "1.0"
-      , cabal-version =
-          prelude.v "2.2"
-      }
+in  prelude.defaults.Package ⫽ { name = "test", version = prelude.v "1.0" }

--- a/golden-tests/cabal-to-dhall/executable.dhall
+++ b/golden-tests/cabal-to-dhall/executable.dhall
@@ -7,6 +7,8 @@ in    prelude.defaults.Package
           "blah"
       , version =
           prelude.v "1"
+      , cabal-version =
+          prelude.v "2.0"
       , executables =
           [ { executable =
                   λ(config : types.Config)

--- a/golden-tests/cabal-to-dhall/gh-36.dhall
+++ b/golden-tests/cabal-to-dhall/gh-36.dhall
@@ -18,6 +18,8 @@ in    prelude.defaults.Package
                 "wai-servlet-debug"
             }
           ]
+      , cabal-version =
+          prelude.v "2.0"
       , library =
           [   λ(config : types.Config)
             →       if config.impl

--- a/golden-tests/cabal-to-dhall/otheros.dhall
+++ b/golden-tests/cabal-to-dhall/otheros.dhall
@@ -7,6 +7,8 @@ in    prelude.defaults.Package
           "test"
       , version =
           prelude.v "0"
+      , cabal-version =
+          prelude.v "2.0"
       , library =
           [   λ(config : types.Config)
             →       if config.os (prelude.types.OSs.OtherOS { _1 = "multics" })

--- a/golden-tests/cabal-to-dhall/simple.dhall
+++ b/golden-tests/cabal-to-dhall/simple.dhall
@@ -2,4 +2,11 @@
 
 in  let types = ./../../dhall/types.dhall
 
-in  prelude.defaults.Package ⫽ { name = "test", version = prelude.v "1.0" }
+in    prelude.defaults.Package
+    ⫽ { name =
+          "test"
+      , version =
+          prelude.v "1.0"
+      , cabal-version =
+          prelude.v "2.0"
+      }

--- a/lib/CabalToDhall.hs
+++ b/lib/CabalToDhall.hs
@@ -251,7 +251,7 @@ packageDefault = fields
       , ( "cabal-version"
         , Expr.App
             ( Expr.Var "prelude" `Expr.Field` "v" )
-            ( Expr.TextLit ( Dhall.Core.Chunks [] "2.0" ) )
+            ( Expr.TextLit ( Dhall.Core.Chunks [] "2.2" ) )
         )
       , textFieldDefault "category" ""
       , textFieldDefault "copyright" ""


### PR DESCRIPTION
This should have been 2.2 but I must have mis-accepted the tests
during all the rebasing. Oops.