### PR TITLE
Changes to allow stack build the project

### DIFF
--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -24,6 +24,7 @@ description:
     (including conditional stanzas).
     .
 category: Distribution
+build-type: Simple
 extra-source-files:
     Changelog.md
     README.md

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -80,6 +80,9 @@ in    prelude.utils.GitHub-project
           ''
       , category =
           "Distribution"
+      , build-type =
+          [ prelude.types.BuildTypes.Simple {=}
+          ] : Optional types.BuildType
       , maintainer =
           "ollie@ocharles.org.uk"
       , author =

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -80,6 +80,7 @@ in    prelude.utils.GitHub-project
           ''
       , category =
           "Distribution"
+      -- build-type simple is needed to allow tools compatible with cabal < 2.2 build the package
       , build-type =
           [ prelude.types.BuildTypes.Simple {=}
           ] : Optional types.BuildType

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,3 @@
-resolver: lts-11.11
+resolver: nightly-2018-06-29
 extra-deps:
-  - Cabal-2.2.0.1
-  - dhall-1.15.0
+- dhall-1.15.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,1 @@
-resolver: nightly-2018-06-29
-extra-deps:
-- dhall-1.15.0
+resolver: lts-12.0


### PR DESCRIPTION
After changes to bump cabal spec version of dhall-to-cabal to 2.2 the project cant be built with stack. I've found 2 issues:
* Last lts can't build cabal files with spec > 2.0 -> i've changed the resolver to nightly
* Even with nightly, stack cant build cabal files without build-type (it thinks that is `custom` by default like cabal spec < 2.2 and throws an error: `No Setup.hs or Setup.lhs file found in D:\ws\eta\dhall\dhall-to-etlas\`).
At least with my version: 1.6.5