### PR TITLE
Set the default default-language to Haskell2010

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 ## NEXT
 
+* The default `default-language` is now `Haskell2010`, rather than nothing.
 
 ## 1.2.0.0 -- 2018-07-05
 

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -206,9 +206,6 @@ in    prelude.utils.GitHub-project
                   , "Dhall.Extra"
                   , "Paths_dhall_to_cabal"
                   ]
-              , default-language =
-                  [ prelude.types.Languages.Haskell2010 {=} ] : Optional
-                                                                types.Language
               }
           )
       , executables =
@@ -238,9 +235,6 @@ in    prelude.utils.GitHub-project
                     [ "Paths_dhall_to_cabal" ]
                 , autogen-modules =
                     [ "Paths_dhall_to_cabal" ]
-                , default-language =
-                    [ prelude.types.Languages.Haskell2010 {=} ] : Optional
-                                                                  types.Language
                 }
             )
           , prelude.unconditional.executable
@@ -267,9 +261,6 @@ in    prelude.utils.GitHub-project
                     [ "Paths_dhall_to_cabal" ]
                 , autogen-modules =
                     [ "Paths_dhall_to_cabal" ]
-                , default-language =
-                    [ prelude.types.Languages.Haskell2010 {=} ] : Optional
-                                                                  types.Language
                 }
             )
           ]
@@ -297,9 +288,6 @@ in    prelude.utils.GitHub-project
                 , type =
                     prelude.types.TestTypes.exitcode-stdio
                     { main-is = "GoldenTests.hs" }
-                , default-language =
-                    [ prelude.types.Languages.Haskell2010 {=} ] : Optional
-                                                                  types.Language
                 }
             )
           ]

--- a/dhall/defaults/BuildInfo.dhall
+++ b/dhall/defaults/BuildInfo.dhall
@@ -26,7 +26,7 @@
 , default-extensions =
     [] : List ../types/Extension.dhall 
 , default-language =
-    [] : Optional ../types/Language.dhall 
+    [ (constructors ../types/Language.dhall).Haskell2010 {=} ] : Optional ../types/Language.dhall 
 , extra-framework-dirs =
     [] : List Text
 , extra-ghci-libraries =

--- a/golden-tests/cabal-to-dhall/benchmark.dhall
+++ b/golden-tests/cabal-to-dhall/benchmark.dhall
@@ -16,6 +16,8 @@ in    prelude.defaults.Package
                     , compiler-options =
                           prelude.defaults.CompilerOptions
                         ⫽ { GHC = [ "-O2" ] : List Text }
+                    , default-language =
+                        [] : Optional types.Language
                     }
             , name =
                 "fancy-benchmark"

--- a/golden-tests/cabal-to-dhall/conditional-dependencies.dhall
+++ b/golden-tests/cabal-to-dhall/conditional-dependencies.dhall
@@ -31,6 +31,8 @@ in    prelude.defaults.Package
                                 , { bounds = prelude.anyVersion, package = "B" }
                                 , { bounds = prelude.anyVersion, package = "C" }
                                 ]
+                            , default-language =
+                                [] : Optional types.Language
                             }
                     
                     else    prelude.defaults.Library
@@ -38,6 +40,8 @@ in    prelude.defaults.Package
                                 [ { bounds = prelude.anyVersion, package = "A" }
                                 , { bounds = prelude.anyVersion, package = "B" }
                                 ]
+                            , default-language =
+                                [] : Optional types.Language
                             }
               
               else  if config.impl
@@ -52,11 +56,15 @@ in    prelude.defaults.Package
                           [ { bounds = prelude.anyVersion, package = "A" }
                           , { bounds = prelude.anyVersion, package = "C" }
                           ]
+                      , default-language =
+                          [] : Optional types.Language
                       }
               
               else    prelude.defaults.Library
                     ⫽ { build-depends =
                           [ { bounds = prelude.anyVersion, package = "A" } ]
+                      , default-language =
+                          [] : Optional types.Language
                       }
           ] : Optional (types.Config → types.Library)
       , license =

--- a/golden-tests/cabal-to-dhall/executable.dhall
+++ b/golden-tests/cabal-to-dhall/executable.dhall
@@ -12,7 +12,12 @@ in    prelude.defaults.Package
       , executables =
           [ { executable =
                   λ(config : types.Config)
-                → prelude.defaults.Executable ⫽ { main-is = "Main.hs" }
+                →   prelude.defaults.Executable
+                  ⫽ { main-is =
+                        "Main.hs"
+                    , default-language =
+                        [] : Optional types.Language
+                    }
             , name =
                 "hello"
             }

--- a/golden-tests/cabal-to-dhall/gh-36.dhall
+++ b/golden-tests/cabal-to-dhall/gh-36.dhall
@@ -50,6 +50,8 @@ in    prelude.defaults.Package
                                             , "-DPURE_JAVA_WITH"
                                             , "-DWAI_SERVLET_DEBUG"
                                             ]
+                                        , default-language =
+                                            [] : Optional types.Language
                                         }
                                 
                                 else    prelude.defaults.Library
@@ -57,6 +59,8 @@ in    prelude.defaults.Package
                                             [ "java/Utils.java" ]
                                         , cpp-options =
                                             [ "-DINTEROP", "-DPURE_JAVA_WITH" ]
+                                        , default-language =
+                                            [] : Optional types.Language
                                         }
                           
                           else  if config.flag "wai-servlet-debug"
@@ -67,11 +71,15 @@ in    prelude.defaults.Package
                                       , "-DPURE_JAVA_WITH"
                                       , "-DWAI_SERVLET_DEBUG"
                                       ]
+                                  , default-language =
+                                      [] : Optional types.Language
                                   }
                           
                           else    prelude.defaults.Library
                                 ⫽ { cpp-options =
                                       [ "-DINTEROP", "-DPURE_JAVA_WITH" ]
+                                  , default-language =
+                                      [] : Optional types.Language
                                   }
                     
                     else  if config.impl
@@ -88,6 +96,8 @@ in    prelude.defaults.Package
                                       [ "java/Utils.java" ]
                                   , cpp-options =
                                       [ "-DINTEROP", "-DWAI_SERVLET_DEBUG" ]
+                                  , default-language =
+                                      [] : Optional types.Language
                                   }
                           
                           else    prelude.defaults.Library
@@ -95,6 +105,8 @@ in    prelude.defaults.Package
                                       [ "java/Utils.java" ]
                                   , cpp-options =
                                       [ "-DINTEROP" ]
+                                  , default-language =
+                                      [] : Optional types.Language
                                   }
                     
                     else  if config.flag "wai-servlet-debug"
@@ -102,10 +114,16 @@ in    prelude.defaults.Package
                     then    prelude.defaults.Library
                           ⫽ { cpp-options =
                                 [ "-DINTEROP", "-DWAI_SERVLET_DEBUG" ]
+                            , default-language =
+                                [] : Optional types.Language
                             }
                     
                     else    prelude.defaults.Library
-                          ⫽ { cpp-options = [ "-DINTEROP" ] }
+                          ⫽ { cpp-options =
+                                [ "-DINTEROP" ]
+                            , default-language =
+                                [] : Optional types.Language
+                            }
               
               else  if config.impl
                        (prelude.types.Compilers.GHC {=})
@@ -127,6 +145,8 @@ in    prelude.defaults.Package
                                       [ "-DPURE_JAVA_WITH"
                                       , "-DWAI_SERVLET_DEBUG"
                                       ]
+                                  , default-language =
+                                      [] : Optional types.Language
                                   }
                           
                           else    prelude.defaults.Library
@@ -134,6 +154,8 @@ in    prelude.defaults.Package
                                       [ "java/Utils.java" ]
                                   , cpp-options =
                                       [ "-DPURE_JAVA_WITH" ]
+                                  , default-language =
+                                      [] : Optional types.Language
                                   }
                     
                     else  if config.flag "wai-servlet-debug"
@@ -141,10 +163,16 @@ in    prelude.defaults.Package
                     then    prelude.defaults.Library
                           ⫽ { cpp-options =
                                 [ "-DPURE_JAVA_WITH", "-DWAI_SERVLET_DEBUG" ]
+                            , default-language =
+                                [] : Optional types.Language
                             }
                     
                     else    prelude.defaults.Library
-                          ⫽ { cpp-options = [ "-DPURE_JAVA_WITH" ] }
+                          ⫽ { cpp-options =
+                                [ "-DPURE_JAVA_WITH" ]
+                            , default-language =
+                                [] : Optional types.Language
+                            }
               
               else  if config.impl
                        (prelude.types.Compilers.GHC {=})
@@ -160,16 +188,27 @@ in    prelude.defaults.Package
                                 [ "java/Utils.java" ]
                             , cpp-options =
                                 [ "-DWAI_SERVLET_DEBUG" ]
+                            , default-language =
+                                [] : Optional types.Language
                             }
                     
                     else    prelude.defaults.Library
-                          ⫽ { c-sources = [ "java/Utils.java" ] }
+                          ⫽ { c-sources =
+                                [ "java/Utils.java" ]
+                            , default-language =
+                                [] : Optional types.Language
+                            }
               
               else  if config.flag "wai-servlet-debug"
               
               then    prelude.defaults.Library
-                    ⫽ { cpp-options = [ "-DWAI_SERVLET_DEBUG" ] }
+                    ⫽ { cpp-options =
+                          [ "-DWAI_SERVLET_DEBUG" ]
+                      , default-language =
+                          [] : Optional types.Language
+                      }
               
-              else  prelude.defaults.Library
+              else    prelude.defaults.Library
+                    ⫽ { default-language = [] : Optional types.Language }
           ] : Optional (types.Config → types.Library)
       }

--- a/golden-tests/cabal-to-dhall/haskell1898.cabal
+++ b/golden-tests/cabal-to-dhall/haskell1898.cabal
@@ -1,0 +1,8 @@
+cabal-version: 2.2
+name: test
+version: 0
+
+library
+  exposed-modules:
+    Foo
+  default-language: Haskell1898

--- a/golden-tests/cabal-to-dhall/haskell1898.dhall
+++ b/golden-tests/cabal-to-dhall/haskell1898.dhall
@@ -1,0 +1,21 @@
+    let prelude = ./../../dhall/prelude.dhall
+
+in  let types = ./../../dhall/types.dhall
+
+in    prelude.defaults.Package
+    ⫽ { name =
+          "test"
+      , version =
+          prelude.v "0"
+      , library =
+          [   λ(config : types.Config)
+            →   prelude.defaults.Library
+              ⫽ { default-language =
+                    [ prelude.types.Languages.UnknownLanguage
+                      { _1 = "Haskell1898" }
+                    ] : Optional types.Language
+                , exposed-modules =
+                    [ "Foo" ]
+                }
+          ] : Optional (types.Config → types.Library)
+      }

--- a/golden-tests/cabal-to-dhall/haskell2010.cabal
+++ b/golden-tests/cabal-to-dhall/haskell2010.cabal
@@ -1,0 +1,8 @@
+cabal-version: 2.2
+name: test
+version: 0
+
+library
+  exposed-modules:
+    Foo
+  default-language: Haskell2010

--- a/golden-tests/cabal-to-dhall/haskell2010.dhall
+++ b/golden-tests/cabal-to-dhall/haskell2010.dhall
@@ -1,0 +1,20 @@
+    let prelude = ./../../dhall/prelude.dhall
+
+in  let types = ./../../dhall/types.dhall
+
+in    prelude.defaults.Package
+    ⫽ { name =
+          "test"
+      , version =
+          prelude.v "0"
+      , library =
+          [   λ(config : types.Config)
+            →   prelude.defaults.Library
+              ⫽ { default-language =
+                    [ prelude.types.Languages.Haskell2010 {=} ] : Optional
+                                                                  types.Language
+                , exposed-modules =
+                    [ "Foo" ]
+                }
+          ] : Optional (types.Config → types.Library)
+      }

--- a/golden-tests/cabal-to-dhall/haskell98.cabal
+++ b/golden-tests/cabal-to-dhall/haskell98.cabal
@@ -1,0 +1,8 @@
+cabal-version: 2.2
+name: test
+version: 0
+
+library
+  exposed-modules:
+    Foo
+  default-language: Haskell98

--- a/golden-tests/cabal-to-dhall/haskell98.dhall
+++ b/golden-tests/cabal-to-dhall/haskell98.dhall
@@ -1,0 +1,20 @@
+    let prelude = ./../../dhall/prelude.dhall
+
+in  let types = ./../../dhall/types.dhall
+
+in    prelude.defaults.Package
+    ⫽ { name =
+          "test"
+      , version =
+          prelude.v "0"
+      , library =
+          [   λ(config : types.Config)
+            →   prelude.defaults.Library
+              ⫽ { default-language =
+                    [ prelude.types.Languages.Haskell98 {=} ] : Optional
+                                                                types.Language
+                , exposed-modules =
+                    [ "Foo" ]
+                }
+          ] : Optional (types.Config → types.Library)
+      }

--- a/golden-tests/cabal-to-dhall/otheros.dhall
+++ b/golden-tests/cabal-to-dhall/otheros.dhall
@@ -14,8 +14,17 @@ in    prelude.defaults.Package
             →       if config.os (prelude.types.OSs.OtherOS { _1 = "multics" })
               
               then    prelude.defaults.Library
-                    ⫽ { exposed-modules = [ "A", "B" ] }
+                    ⫽ { default-language =
+                          [] : Optional types.Language
+                      , exposed-modules =
+                          [ "A", "B" ]
+                      }
               
-              else  prelude.defaults.Library ⫽ { exposed-modules = [ "A" ] }
+              else    prelude.defaults.Library
+                    ⫽ { default-language =
+                          [] : Optional types.Language
+                      , exposed-modules =
+                          [ "A" ]
+                      }
           ] : Optional (types.Config → types.Library)
       }

--- a/golden-tests/dhall-to-cabal/SPDX.cabal
+++ b/golden-tests/dhall-to-cabal/SPDX.cabal
@@ -4,3 +4,4 @@ version: 0
 license: (AGPL-3.0-or-later OR Apache-2.0+ WITH Classpath-exception-2.0) AND (LicenseRef-MyFancyLicense OR DocumentRef-LICENSE.txt:LicenseRef-MyFancierLicense)
 
 library
+    default-language: Haskell2010

--- a/golden-tests/dhall-to-cabal/allrightsreserved-2.0.cabal
+++ b/golden-tests/dhall-to-cabal/allrightsreserved-2.0.cabal
@@ -4,3 +4,4 @@ version: 0
 license: AllRightsReserved
 
 library
+    default-language: Haskell2010

--- a/golden-tests/dhall-to-cabal/compiler-options-order.cabal
+++ b/golden-tests/dhall-to-cabal/compiler-options-order.cabal
@@ -1,12 +1,12 @@
 cabal-version: 2.2
 name: Name
 version: 1
-license: NONE
 
 library
     exposed-modules:
         Foo
         Bar
+    default-language: Haskell2010
     
     if impl(ghc >=8.2)
         

--- a/golden-tests/dhall-to-cabal/conditional-dependencies.cabal
+++ b/golden-tests/dhall-to-cabal/conditional-dependencies.cabal
@@ -1,9 +1,9 @@
 cabal-version: 2.2
 name: Name
 version: 1
-license: NONE
 
 library
+    default-language: Haskell2010
     build-depends:
         A -any
     

--- a/golden-tests/dhall-to-cabal/default-license-2.2.cabal
+++ b/golden-tests/dhall-to-cabal/default-license-2.2.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name: foo
 version: 0
-license: NONE
 
 library
+    default-language: Haskell2010

--- a/golden-tests/dhall-to-cabal/empty-package.cabal
+++ b/golden-tests/dhall-to-cabal/empty-package.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 name: Name
 version: 1
-license: NONE
 
 executable foo
     main-is: Main.hs
+    default-language: Haskell2010

--- a/golden-tests/dhall-to-cabal/gh-53.cabal
+++ b/golden-tests/dhall-to-cabal/gh-53.cabal
@@ -9,6 +9,7 @@ flag wai-servlet-debug
     default: False
 
 library
+    default-language: Haskell2010
     
     if impl(ghc >=0.0.9)
         c-sources:

--- a/golden-tests/dhall-to-cabal/gh-55.cabal
+++ b/golden-tests/dhall-to-cabal/gh-55.cabal
@@ -1,11 +1,11 @@
 cabal-version: 2.2
 name: Name
 version: 1
-license: NONE
 
 library
     exposed-modules:
         Module1
+    default-language: Haskell2010
     
     if impl(ghc >=7.1.3)
         exposed-modules:

--- a/golden-tests/dhall-to-cabal/haskell1898.cabal
+++ b/golden-tests/dhall-to-cabal/haskell1898.cabal
@@ -3,4 +3,4 @@ name: foo
 version: 0
 
 library
-    default-language: Haskell2010
+  default-language: Haskell1898

--- a/golden-tests/dhall-to-cabal/haskell1898.dhall
+++ b/golden-tests/dhall-to-cabal/haskell1898.dhall
@@ -1,0 +1,13 @@
+   let prelude = ./dhall/prelude.dhall
+in let types = ./dhall/types.dhall
+in   prelude.defaults.Package
+  // { name = "foo"
+     , version = prelude.v "0"
+     , library = prelude.unconditional.library
+         ( prelude.defaults.Library
+        // { default-language =
+               [ prelude.types.Languages.UnknownLanguage { _1 = "Haskell1898" }
+               ] : Optional types.Language
+           }
+         )
+     }

--- a/golden-tests/dhall-to-cabal/haskell98.cabal
+++ b/golden-tests/dhall-to-cabal/haskell98.cabal
@@ -3,4 +3,4 @@ name: foo
 version: 0
 
 library
-    default-language: Haskell2010
+  default-language: Haskell98

--- a/golden-tests/dhall-to-cabal/haskell98.dhall
+++ b/golden-tests/dhall-to-cabal/haskell98.dhall
@@ -1,0 +1,13 @@
+   let prelude = ./dhall/prelude.dhall
+in let types = ./dhall/types.dhall
+in   prelude.defaults.Package
+  // { name = "foo"
+     , version = prelude.v "0"
+     , library = prelude.unconditional.library
+          ( prelude.defaults.Library
+         // { default-language =
+                [ prelude.types.Languages.Haskell98 {=}
+                ] : Optional types.Language
+            }
+          )
+     }

--- a/golden-tests/dhall-to-cabal/map-source-repo.cabal
+++ b/golden-tests/dhall-to-cabal/map-source-repo.cabal
@@ -1,7 +1,6 @@
 cabal-version: 2.2
 name: repo
 version: 1.0.0
-license: NONE
 homepage: https://github.com/owner/repo
 bug-reports: https://github.com/owner/repo/issues
 
@@ -12,3 +11,4 @@ source-repository this
 
 executable foo
     main-is: Main.hs
+    default-language: Haskell2010

--- a/golden-tests/dhall-to-cabal/nested-conditions.cabal
+++ b/golden-tests/dhall-to-cabal/nested-conditions.cabal
@@ -1,9 +1,9 @@
 cabal-version: 2.2
 name: foo
 version: 0
-license: NONE
 
 library
+    default-language: Haskell2010
     
     if impl(ghc >=8.2)
         


### PR DESCRIPTION
This is another divergence from Cabal's defaults, but it's quite good
for our usability. We can figure out a plan to deal with Haskell2020
or whatever when it comes.
