### PR TITLE
Fully support the mixins field.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 # dhall-to-cabal change log
 
+## NEXT
+
+* `dhall-to-cabal` and `cabal-to-dhall` now understand the `mixins`
+  field properly.
+
+  On the Dhall side, `types.ModuleRenaming` has changed significantly:
+  it is now a union.
+
+  `prelude.types.ModuleRenaming` has been added for convenient access
+  to the new constructors.
+
 ## 1.3.0.1 -- 2018-08-10
 
 ### Distribution Changes

--- a/dhall/prelude.dhall
+++ b/dhall/prelude.dhall
@@ -15,6 +15,8 @@
         constructors ./types/SPDX/LicenseExceptionId.dhall
     , LicenseId =
         constructors ./types/SPDX/LicenseId.dhall
+    , ModuleRenaming =
+        constructors ./types/ModuleRenaming.dhall
     , TestTypes =
         constructors ./types/TestType.dhall
     , RepoType =

--- a/dhall/types/ModuleRenaming.dhall
+++ b/dhall/types/ModuleRenaming.dhall
@@ -1,1 +1,7 @@
-List { rename : Text, to : Text }
+< renaming :
+    List { rename : Text, to : Text }
+| default :
+    {}
+| hiding :
+    List Text
+>

--- a/golden-tests/cabal-to-dhall/mixins-no-signatures.cabal
+++ b/golden-tests/cabal-to-dhall/mixins-no-signatures.cabal
@@ -1,0 +1,9 @@
+cabal-version: 2.2
+name: mixins-test
+version: 0
+
+library
+  mixins:
+    foo,
+    bar (Some.Module, Some.Other.Module, Third.Module as Renamed),
+    baz hiding (Hidden, Also.Hidden)

--- a/golden-tests/cabal-to-dhall/mixins-no-signatures.dhall
+++ b/golden-tests/cabal-to-dhall/mixins-no-signatures.dhall
@@ -1,0 +1,53 @@
+    let prelude = ./../../dhall/prelude.dhall
+
+in  let types = ./../../dhall/types.dhall
+
+in    prelude.defaults.Package
+    ⫽ { name =
+          "mixins-test"
+      , version =
+          prelude.v "0"
+      , library =
+          [   λ(config : types.Config)
+            →   prelude.defaults.Library
+              ⫽ { mixins =
+                    [ { package =
+                          "foo"
+                      , renaming =
+                          { provides =
+                              prelude.types.ModuleRenaming.default {=}
+                          , requires =
+                              prelude.types.ModuleRenaming.default {=}
+                          }
+                      }
+                    , { package =
+                          "bar"
+                      , renaming =
+                          { provides =
+                              prelude.types.ModuleRenaming.renaming
+                              [ { rename = "Some.Module", to = "Some.Module" }
+                              , { rename =
+                                    "Some.Other.Module"
+                                , to =
+                                    "Some.Other.Module"
+                                }
+                              , { rename = "Third.Module", to = "Renamed" }
+                              ]
+                          , requires =
+                              prelude.types.ModuleRenaming.default {=}
+                          }
+                      }
+                    , { package =
+                          "baz"
+                      , renaming =
+                          { provides =
+                              prelude.types.ModuleRenaming.hiding
+                              [ "Hidden", "Also.Hidden" ]
+                          , requires =
+                              prelude.types.ModuleRenaming.default {=}
+                          }
+                      }
+                    ]
+                }
+          ] : Optional (types.Config → types.Library)
+      }

--- a/golden-tests/dhall-to-cabal/mixins-no-signatures.cabal
+++ b/golden-tests/dhall-to-cabal/mixins-no-signatures.cabal
@@ -1,0 +1,9 @@
+cabal-version: 2.2
+name: mixins-test
+version: 0
+
+library
+  mixins:
+    foo,
+    bar (Some.Module, Some.Other.Module, Third.Module as Renamed),
+    baz hiding (Hidden, Also.Hidden)

--- a/golden-tests/dhall-to-cabal/mixins-no-signatures.dhall
+++ b/golden-tests/dhall-to-cabal/mixins-no-signatures.dhall
@@ -1,0 +1,53 @@
+    let prelude = ./../../dhall/prelude.dhall
+
+in  let types = ./../../dhall/types.dhall
+
+in    prelude.defaults.Package
+    ⫽ { name =
+          "mixins-test"
+      , version =
+          prelude.v "0"
+      , library =
+          [   λ(config : types.Config)
+            →   prelude.defaults.Library
+              ⫽ { mixins =
+                    [ { package =
+                          "foo"
+                      , renaming =
+                          { provides =
+                              prelude.types.ModuleRenaming.default {=}
+                          , requires =
+                              prelude.types.ModuleRenaming.default {=}
+                          }
+                      }
+                    , { package =
+                          "bar"
+                      , renaming =
+                          { provides =
+                              prelude.types.ModuleRenaming.renaming
+                              [ { rename = "Some.Module", to = "Some.Module" }
+                              , { rename =
+                                    "Some.Other.Module"
+                                , to =
+                                    "Some.Other.Module"
+                                }
+                              , { rename = "Third.Module", to = "Renamed" }
+                              ]
+                          , requires =
+                              prelude.types.ModuleRenaming.default {=}
+                          }
+                      }
+                    , { package =
+                          "baz"
+                      , renaming =
+                          { provides =
+                              prelude.types.ModuleRenaming.hiding
+                              [ "Hidden", "Also.Hidden" ]
+                          , requires =
+                              prelude.types.ModuleRenaming.default {=}
+                          }
+                      }
+                    ]
+                }
+          ] : Optional (types.Config → types.Library)
+      }

--- a/lib/DhallToCabal.hs
+++ b/lib/DhallToCabal.hs
@@ -1326,10 +1326,25 @@ includeRenaming =
 
 moduleRenaming :: Dhall.Type Cabal.ModuleRenaming
 moduleRenaming =
-  fmap Cabal.ModuleRenaming $
-  Dhall.list $
-  Dhall.record $
-    (,) <$> Dhall.field "rename" moduleName <*> Dhall.field "to" moduleName
+  makeUnion
+    ( Map.fromList
+      [ ( "renaming"
+        , fmap Cabal.ModuleRenaming
+            ( Dhall.list
+              ( Dhall.record
+                ( (,) <$> Dhall.field "rename" moduleName <*> Dhall.field "to" moduleName )
+              )
+            )
+        )
+      , ( "default"
+        , Dhall.record ( pure Cabal.DefaultRenaming )
+        )
+      , ( "hiding"
+        , fmap Cabal.HidingRenaming
+            ( Dhall.list moduleName )
+        )
+      ]
+    )
 
 
 sortType :: Dhall.Type a -> Dhall.Type a


### PR DESCRIPTION
Previously, only the `ModuleRenaming` case was handled. However, there
are two other cases: `DefaultRenaming` and `HidingRenaming`. This
commit adds support for both of those, reducing one more place where
`cabal-to-dhall` can crash.

On the Dhall side, types/ModuleRenaming.dhall is now a union that
closely matches its Cabal-side reflection. The constructors of this
union are exported through the prelude for convenience.

There may be some room for additional convenience functions in Dhall
here, but I'm happy with just having the functionality available.