### PR TITLE
Add missing dhall/types/BuildInfo.dhall to extra-source-files.

### DIFF
--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -61,6 +61,7 @@ extra-source-files:
     dhall/types.dhall
     dhall/types/Arch.dhall
     dhall/types/Benchmark.dhall
+    dhall/types/BuildInfo.dhall
     dhall/types/BuildType.dhall
     dhall/types/Compiler.dhall
     dhall/types/CompilerOptions.dhall

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -129,6 +129,7 @@ in    prelude.utils.GitHub-project
           , "dhall/types.dhall"
           , "dhall/types/Arch.dhall"
           , "dhall/types/Benchmark.dhall"
+          , "dhall/types/BuildInfo.dhall"
           , "dhall/types/BuildType.dhall"
           , "dhall/types/Compiler.dhall"
           , "dhall/types/CompilerOptions.dhall"


### PR DESCRIPTION
I guess no-one has been testing the sdists, so this was only uncovered
by Stackage.

Should fix commercialhaskell/stackage#3899.