### PR TITLE
Allow dhall-1.17.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## NEXT
 
+* Allow `dhall` version 1.17.
+
 * `dhall-to-cabal` and `cabal-to-dhall` now understand the `mixins`
   field properly.
 

--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -134,7 +134,7 @@ library
         bytestring ^>=0.10,
         containers ^>=0.5 || ^>=0.6,
         contravariant ^>=1.4 || ^>=1.5,
-        dhall ^>=1.16.0,
+        dhall ^>=1.17.0,
         hashable ^>=1.2.6.1,
         insert-ordered-containers ^>=0.2.1.0,
         text ^>=1.2,
@@ -158,7 +158,7 @@ executable dhall-to-cabal
     build-depends:
         Cabal ^>=2.2,
         base ^>=4.10 || ^>=4.11 || ^>=4.12,
-        dhall ^>=1.16.0,
+        dhall ^>=1.17.0,
         dhall-to-cabal -any,
         filepath ^>=1.4,
         insert-ordered-containers ^>=0.2.1.0,
@@ -184,7 +184,7 @@ executable cabal-to-dhall
                  -fno-warn-name-shadowing
     build-depends:
         base ^>=4.10 || ^>=4.11 || ^>=4.12,
-        dhall ^>=1.16.0,
+        dhall ^>=1.17.0,
         bytestring ^>=0.10,
         dhall-to-cabal -any,
         optparse-applicative ^>=0.13.2 || ^>=0.14,
@@ -204,7 +204,7 @@ executable dhall-to-cabal-meta
     build-depends:
         base ^>=4.10 || ^>=4.11 || ^>=4.12,
         directory ^>=1.3.0.2,
-        dhall ^>=1.16.0,
+        dhall ^>=1.17.0,
         dhall-to-cabal -any,
         filepath ^>=1.4,
         optparse-applicative ^>=0.13.2 || ^>=0.14,
@@ -225,7 +225,7 @@ test-suite golden-tests
         Cabal ^>=2.2,
         Diff ^>=0.3.4,
         bytestring ^>=0.10,
-        dhall ^>=1.16.0,
+        dhall ^>=1.17.0,
         dhall-to-cabal -any,
         filepath ^>=1.4,
         microlens ^>=0.1.0.0 || ^>=0.2.0.0 || ^>=0.3.0.0 || ^>=0.4.0.0,

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -29,7 +29,7 @@ in  let deps =
           , directory =
               majorVersions "directory" [ v "1.3.0.2" ]
           , dhall =
-              majorVersions "dhall" [ v "1.16.0" ]
+              majorVersions "dhall" [ v "1.17.0" ]
           , dhall-to-cabal =
               package "dhall-to-cabal" anyVersion
           , filepath =

--- a/dhall.nix
+++ b/dhall.nix
@@ -1,33 +1,38 @@
 { mkDerivation, ansi-terminal, base, bytestring, case-insensitive
-, containers, contravariant, criterion, cryptonite, deepseq, Diff
-, directory, doctest, exceptions, filepath, haskeline, http-client
-, http-client-tls, insert-ordered-containers, lens-family-core
-, megaparsec, memory, mockery, mtl, optparse-applicative, parsers
-, prettyprinter, prettyprinter-ansi-terminal, repline, scientific
-, stdenv, tasty, tasty-hunit, template-haskell, text, transformers
+, cborg, containers, contravariant, criterion, cryptonite, deepseq
+, Diff, directory, doctest, exceptions, filepath, hashable
+, haskeline, http-client, http-client-tls
+, insert-ordered-containers, lens-family-core, megaparsec, memory
+, mockery, mtl, optparse-applicative, parsers, prettyprinter
+, prettyprinter-ansi-terminal, QuickCheck, quickcheck-instances
+, repline, scientific, serialise, stdenv, tasty, tasty-hunit
+, tasty-quickcheck, template-haskell, text, transformers
 , unordered-containers, vector
 }:
 mkDerivation {
   pname = "dhall";
-  version = "1.16.1";
-  sha256 = "02a69a5d6c61b646a3a3822f6e077c2d298624baa142148af108bfe004e9c0d5";
+  version = "1.17.0";
+  sha256 = "a029fea856224a79f0b7cc56fbb5c566d0dfd1d915d214f682006cabf1274791";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    ansi-terminal base bytestring case-insensitive containers
+    ansi-terminal base bytestring case-insensitive cborg containers
     contravariant cryptonite Diff directory exceptions filepath
-    haskeline http-client http-client-tls insert-ordered-containers
-    lens-family-core megaparsec memory mtl optparse-applicative parsers
-    prettyprinter prettyprinter-ansi-terminal repline scientific
+    hashable haskeline http-client http-client-tls
+    insert-ordered-containers lens-family-core megaparsec memory mtl
+    optparse-applicative parsers prettyprinter
+    prettyprinter-ansi-terminal repline scientific serialise
     template-haskell text transformers unordered-containers vector
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
-    base deepseq directory doctest filepath insert-ordered-containers
-    mockery prettyprinter tasty tasty-hunit text vector
+    base containers deepseq directory doctest filepath hashable
+    insert-ordered-containers mockery prettyprinter QuickCheck
+    quickcheck-instances serialise tasty tasty-hunit tasty-quickcheck
+    text transformers vector
   ];
   benchmarkHaskellDepends = [
-    base containers criterion directory text
+    base bytestring containers criterion directory serialise text
   ];
   description = "A configuration language guaranteed to terminate";
   license = stdenv.lib.licenses.bsd3;

--- a/dhall.nix
+++ b/dhall.nix
@@ -34,6 +34,7 @@ mkDerivation {
   benchmarkHaskellDepends = [
     base bytestring containers criterion directory serialise text
   ];
+  doCheck = false;
   description = "A configuration language guaranteed to terminate";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/lib/DhallLocation.hs
+++ b/lib/DhallLocation.hs
@@ -34,14 +34,18 @@ dhallFromGitHub =
                 { Dhall.Core.hash =
                     Nothing
                 , Dhall.Core.importType =
-                    Dhall.Core.URL
-                      "https://raw.githubusercontent.com"
-                      ( Dhall.Core.File
-                         ( Dhall.Core.Directory [ "dhall", version, "dhall-to-cabal", "dhall-lang" ] )
-                         "prelude.dhall"
+                    Dhall.Core.Remote
+                      ( Dhall.Core.URL
+                          Dhall.Core.HTTPS
+                          "https://raw.githubusercontent.com"
+                          ( Dhall.Core.File
+                             ( Dhall.Core.Directory [ "dhall", version, "dhall-to-cabal", "dhall-lang" ] )
+                             "prelude.dhall"
+                          )
+                          Nothing
+                          Nothing
+                          Nothing
                       )
-                      ""
-                      Nothing
                 }
           , Dhall.Core.importMode =
               Dhall.Core.Code
@@ -54,14 +58,18 @@ dhallFromGitHub =
                 { Dhall.Core.hash =
                     Nothing
                 , Dhall.Core.importType =
-                    Dhall.Core.URL
-                      "https://raw.githubusercontent.com"
-                      ( Dhall.Core.File
-                         ( Dhall.Core.Directory [ "dhall", version, "dhall-to-cabal", "dhall-lang" ] )
-                         "types.dhall"
+                    Dhall.Core.Remote
+                      ( Dhall.Core.URL
+                          Dhall.Core.HTTPS
+                          "https://raw.githubusercontent.com"
+                          ( Dhall.Core.File
+                             ( Dhall.Core.Directory [ "dhall", version, "dhall-to-cabal", "dhall-lang" ] )
+                             "types.dhall"
+                          )
+                          Nothing
+                          Nothing
+                          Nothing
                       )
-                      ""
-                      Nothing
                 }
           , Dhall.Core.importMode =
               Dhall.Core.Code

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,11 @@
 resolver: lts-12.0
+packages:
+  - .
 extra-deps:
-  - dhall-1.16.1@rev:0
+  - dhall-1.17.0@rev:0
+  # Version 0.2.0.0 of cborg, the latest on Hackage, is broken on i386.
+  - github: well-typed/cborg
+    commit: master
+    subdirs:
+      - cborg
+      - serialise


### PR DESCRIPTION
To help unblock commercialhaskell/stackage#3945.

Not sure if this should go in and be released until we figure out what's up with #124. If it's a pre-existing problem I'd say to go for it, but if it's a regression we should hold back, and since we don't know we've got to assume it's a regression.