### PR TITLE
Release 1.3.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,11 +1,11 @@
 # dhall-to-cabal change log
 
-## NEXT
+## 1.3.1.0 -- 2018-10-23
 
 * Allow `Cabal` version 2.4.0.0. There have been consequent changes to
   the extensions, compilers and licenses recognised.
 
-* Allow `dhall` version 1.17.
+* Allow `dhall` version 1.18.
 
 * `dhall-to-cabal` and `cabal-to-dhall` now understand the `mixins`
   field properly.
@@ -15,6 +15,10 @@
 
   `prelude.types.ModuleRenaming` has been added for convenient access
   to the new constructors.
+
+* Fix issue with alpha-normalized expressions. This was identified in issue #124
+  and fixed in issue #126.
+
 
 ## 1.3.0.1 -- 2018-08-10
 

--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -9,7 +9,7 @@ cabal-version: 2.2
 -- 'dhall-to-cabal -- dhall-to-cabal.dhall > dhall-to-cabal.cabal'.
 -- * * * * * * * * * * * * WARNING * * * * * * * * * * * *
 name: dhall-to-cabal
-version: 1.4.0.0
+version: 1.3.1.0
 license: MIT
 license-file: LICENSE
 maintainer: ollie@ocharles.org.uk

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -176,7 +176,7 @@ in    prelude.utils.GitHub-project
       , license-files =
           [ "LICENSE" ]
       , version =
-          v "1.4.0.0"
+          v "1.3.1.0"
       , library =
           prelude.unconditional.library
           (   prelude.defaults.Library


### PR DESCRIPTION
There are actually no breaking API changes this release that I can see (https://github.com/dhall-lang/dhall-to-cabal/compare/1.3.0.0...master), so this takes us from 1.3.0.1 to 1.3.1.0.

Fixes #139.