### PR TITLE
Bump nightly resolver to one with Dhall 1.21 in it.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,4 @@
-resolver: lts-13.7
+resolver: nightly-2019-04-28
 packages:
   - .
-extra-deps:
-  - dhall-1.20.1
-  - Cabal-2.4.0.0
-  - tasty-1.1.0.4
 


### PR DESCRIPTION
Should've done this as part of #149 - ah well. I did make sure it
worked on the other two build systems!