### PR TITLE
Use License.Unknown instead License.Unspecified

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ## Next
 
+* Fix `cabal-to-dhall` output for unknown licenses using `cabal` spec
+  version below `2.0`. Now it uses values of type `License.Unknown Text` 
+  for them.
+
 * Use `dhall` version 1.21.0.
 
 ## 1.3.2.0 -- 2019-02-12

--- a/golden-tests/cabal-to-dhall/unknown-license.cabal
+++ b/golden-tests/cabal-to-dhall/unknown-license.cabal
@@ -1,0 +1,4 @@
+cabal-version: 1.12
+name: test
+version: 1.0
+license: MYUnknownLicense

--- a/golden-tests/cabal-to-dhall/unknown-license.dhall
+++ b/golden-tests/cabal-to-dhall/unknown-license.dhall
@@ -1,0 +1,14 @@
+let prelude = ./../../dhall/prelude.dhall
+
+let types = ./../../dhall/types.dhall
+
+in    prelude.defaults.Package
+    ⫽ { name =
+          "test"
+      , version =
+          prelude.v "1.0"
+      , cabal-version =
+          prelude.v "1.12"
+      , license =
+          types.License.Unknown "MYUnknownLicense"
+      }

--- a/lib/CabalToDhall.hs
+++ b/lib/CabalToDhall.hs
@@ -647,7 +647,7 @@ licenseToDhall =
           Right ( Cabal.UnknownLicense "UnspecifiedLicense" ) ->
             license "Unspecified" ( Expr.RecordLit mempty )
           Right ( Cabal.UnknownLicense l ) ->
-            license "Unspecified" ( Expr.TextLit (Expr.Chunks [] (StrictText.pack l)) )
+            license "Unknown" ( Expr.TextLit (Expr.Chunks [] (StrictText.pack l)) )
           Right Cabal.OtherLicense ->
             license "Other" ( Expr.RecordLit mempty )
           Left ( SPDX.License x ) ->


### PR DESCRIPTION
As discused in https://github.com/dhall-lang/dhall-to-cabal/pull/150#discussion_r283276452
Setting an unkown license with cabal spec < 2.0 throwed an error cause `License.Unspecified` doesnt take a `Text` arg 