### PR TITLE
Remove CustomSetup in favour of SetupBuildInfo.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # dhall-to-cabal change log
 
+## Next -- [YYYY-MM-DD]
+
+* Remove `dhall/types/CustomSetup.dhall` in favour of the identical
+  `dhall/types/SetupBuildInfo.dhall`.
+
 ## 1.3.3.0 -- 2019-05-15
 
 * All constructors that previously took an empty record now use the

--- a/dhall/defaults/Package.dhall
+++ b/dhall/defaults/Package.dhall
@@ -82,5 +82,5 @@ in  { author =
     , x-fields =
         [] : List { _1 : Text, _2 : Text }
     , custom-setup =
-        None types.CustomSetup
+        None types.SetupBuildInfo
     }

--- a/dhall/types.dhall
+++ b/dhall/types.dhall
@@ -10,8 +10,6 @@
     ./types/CompilerOptions.dhall
 , Config =
     ./types/Config.dhall
-, CustomSetup =
-    ./types/CustomSetup.dhall
 , Dependency =
     ./types/Dependency.dhall
 , Executable =

--- a/dhall/types/CustomSetup.dhall
+++ b/dhall/types/CustomSetup.dhall
@@ -1,1 +1,0 @@
-{ setup-depends : List ./Dependency.dhall }

--- a/dhall/types/Package.dhall
+++ b/dhall/types/Package.dhall
@@ -13,7 +13,7 @@
 , copyright :
     Text
 , custom-setup :
-    Optional ./CustomSetup.dhall
+    Optional ./SetupBuildInfo.dhall
 , data-dir :
     Text
 , data-files :

--- a/lib/CabalToDhall.hs
+++ b/lib/CabalToDhall.hs
@@ -1029,7 +1029,7 @@ setupBuildInfo =
       )
   )
     { Dhall.declared =
-        Expr.Var "types" `Expr.Field` "CustomSetup"
+        Expr.Var "types" `Expr.Field` "SetupBuildInfo"
     }
 
 


### PR DESCRIPTION
The files are identical, and the decider in favour of doing it this
way around is that SBI was used in slightly more places than CS.

In *theory* it makes sense to separate the buildinfo-ish parts from
the other parts, but in practice the latter set is null, and there's
unlikely to ever be something that'll work similarly enough to
custom-setup that it'll warrant the sharing.

squash! Remove CustomSetup in favour of SetupBuildInfo.