### PR TITLE
Replace & remove runUnion

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 
 * Added `dhall/types/ForeignLibOption.dhall`, also available as
   `types.ForeignLibOption`, and `--print-type ForeignLibOption`.
+  Likewise `ForeignLibType`.
 
 ## 1.3.3.0 -- 2019-05-15
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@
 * Remove `dhall/types/CustomSetup.dhall` in favour of the identical
   `dhall/types/SetupBuildInfo.dhall`.
 
+* Added `dhall/types/ForeignLibOption.dhall`, also available as
+  `types.ForeignLibOption`, and `--print-type ForeignLibOption`.
+
 ## 1.3.3.0 -- 2019-05-15
 
 * All constructors that previously took an empty record now use the

--- a/dhall/types.dhall
+++ b/dhall/types.dhall
@@ -22,6 +22,8 @@
     ./types/Flag.dhall
 , ForeignLibOption =
     ./types/ForeignLibOption.dhall
+, ForeignLibType =
+    ./types/ForeignLibType.dhall
 , ForeignLibrary =
     ./types/ForeignLibrary.dhall
 , Language =

--- a/dhall/types.dhall
+++ b/dhall/types.dhall
@@ -20,6 +20,8 @@
     ./types/Extension.dhall
 , Flag =
     ./types/Flag.dhall
+, ForeignLibOption =
+    ./types/ForeignLibOption.dhall
 , ForeignLibrary =
     ./types/ForeignLibrary.dhall
 , Language =

--- a/dhall/types/ForeignLibOption.dhall
+++ b/dhall/types/ForeignLibOption.dhall
@@ -1,0 +1,1 @@
+< Standalone >

--- a/dhall/types/ForeignLibType.dhall
+++ b/dhall/types/ForeignLibType.dhall
@@ -1,0 +1,1 @@
+< Shared | Static >

--- a/dhall/types/ForeignLibrary.dhall
+++ b/dhall/types/ForeignLibrary.dhall
@@ -1,6 +1,6 @@
   ./BuildInfo.dhall
 ⩓ { type :
-      < Shared | Static >
+      ./ForeignLibType.dhall
   , options :
       List ./ForeignLibOption.dhall
   , lib-version-info :

--- a/dhall/types/ForeignLibrary.dhall
+++ b/dhall/types/ForeignLibrary.dhall
@@ -2,7 +2,7 @@
 ⩓ { type :
       < Shared | Static >
   , options :
-      List < Standalone >
+      List ./ForeignLibOption.dhall
   , lib-version-info :
       Optional { current : Natural, revision : Natural, age : Natural }
   , lib-version-linux :

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -86,6 +86,7 @@ data KnownType
   | LicenseExceptionId
   | Scope
   | ModuleRenaming
+  | ForeignLibOption
   deriving (Bounded, Enum, Eq, Ord, Read, Show)
 
 
@@ -467,6 +468,7 @@ printType PrintTypeOptions { .. } = do
           LicenseExceptionId -> Dhall.expected spdxLicenseExceptionId
           Scope -> Dhall.expected executableScope
           ModuleRenaming -> Dhall.expected moduleRenaming
+          ForeignLibOption -> Dhall.expected foreignLibOption
       )
 
     makeLetOrImport t val reduced =

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -87,6 +87,7 @@ data KnownType
   | Scope
   | ModuleRenaming
   | ForeignLibOption
+  | ForeignLibType
   deriving (Bounded, Enum, Eq, Ord, Read, Show)
 
 
@@ -469,6 +470,7 @@ printType PrintTypeOptions { .. } = do
           Scope -> Dhall.expected executableScope
           ModuleRenaming -> Dhall.expected moduleRenaming
           ForeignLibOption -> Dhall.expected foreignLibOption
+          ForeignLibType -> Dhall.expected foreignLibType
       )
 
     makeLetOrImport t val reduced =

--- a/lib/CabalToDhall.hs
+++ b/lib/CabalToDhall.hs
@@ -1651,9 +1651,15 @@ foreignLibOption =
 
 foreignLibType :: Dhall.InputType Cabal.ForeignLibType
 foreignLibType =
-  runUnion
-    ( mconcat
-        [ unionAlt "Shared" ( \x -> case x of Cabal.ForeignLibNativeShared -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "Static" ( \x -> case x of Cabal.ForeignLibNativeStatic -> Just () ; _ -> Nothing ) Dhall.inject
-        ]
-    )
+  Dhall.InputType
+    { Dhall.embed = \case
+        Cabal.ForeignLibNativeShared ->
+          ty "Shared"
+        Cabal.ForeignLibNativeStatic ->
+          ty "Static"
+    , Dhall.declared =
+        Expr.Var "types" `Expr.Field` "ForeignLibType"
+    }
+  where
+  ty name =
+    Expr.Var "types" `Expr.Field` "ForeignLibType" `Expr.Field` name

--- a/lib/CabalToDhall.hs
+++ b/lib/CabalToDhall.hs
@@ -1237,27 +1237,52 @@ os =
 
 arch :: Dhall.InputType Cabal.Arch
 arch =
-  runUnion
-    ( mconcat
-        [ unionAlt "I386" ( \x -> case x of Cabal.I386 -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "X86_64" ( \x -> case x of Cabal.X86_64 -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "PPC" ( \x -> case x of Cabal.PPC -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "PPC64" ( \x -> case x of Cabal.PPC64 -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "Sparc" ( \x -> case x of Cabal.Sparc -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "Arm" ( \x -> case x of Cabal.Arm -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "Mips" ( \x -> case x of Cabal.Mips -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "SH" ( \x -> case x of Cabal.SH -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "IA64" ( \x -> case x of Cabal.IA64 -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "S390" ( \x -> case x of Cabal.S390 -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "Alpha" ( \x -> case x of Cabal.Alpha -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "Hppa" ( \x -> case x of Cabal.Hppa -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "Rs6000" ( \x -> case x of Cabal.Rs6000 -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "M68k" ( \x -> case x of Cabal.M68k -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "Vax" ( \x -> case x of Cabal.Vax -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "JavaScript" ( \x -> case x of Cabal.JavaScript -> Just () ; _ -> Nothing ) Dhall.inject
-        , unionAlt "OtherArch" ( \x -> case x of Cabal.OtherArch s -> Just s ; _ -> Nothing ) ( runRecordInputType ( recordField "_1" stringToDhall ) )
-        ]
-    )
+  Dhall.InputType
+    { Dhall.embed = \case
+        Cabal.I386 ->
+          arch "I386"
+        Cabal.X86_64 ->
+          arch "X86_64"
+        Cabal.PPC ->
+          arch "PPC"
+        Cabal.PPC64 ->
+          arch "PPC64"
+        Cabal.Sparc ->
+          arch "Sparc"
+        Cabal.Arm ->
+          arch "Arm"
+        Cabal.Mips ->
+          arch "Mips"
+        Cabal.SH ->
+          arch "SH"
+        Cabal.IA64 ->
+          arch "IA64"
+        Cabal.S390 ->
+          arch "S390"
+        Cabal.Alpha ->
+          arch "Alpha"
+        Cabal.Hppa ->
+          arch "Hppa"
+        Cabal.Rs6000 ->
+          arch "Rs6000"
+        Cabal.M68k ->
+          arch "M68k"
+        Cabal.Vax ->
+          arch "Vax"
+        Cabal.JavaScript ->
+          arch "JavaScript"
+        Cabal.AArch64 ->
+          arch "AArch64"
+        Cabal.OtherArch s ->
+          Expr.App
+            ( arch "OtherArch" )
+            ( Expr.RecordLit ( Map.singleton "_1" ( dhallString s ) ) )
+    , Dhall.declared =
+        Expr.Var "types" `Expr.Field` "Arch"
+    }
+  where
+  arch name =
+    Expr.Var "types" `Expr.Field` "Arch" `Expr.Field` name
 
 
 buildInfoRecord :: RecordInputType Cabal.BuildInfo

--- a/lib/CabalToDhall.hs
+++ b/lib/CabalToDhall.hs
@@ -1390,17 +1390,22 @@ pkgconfigName =
 
 language :: Dhall.InputType Cabal.Language
 language =
-  ( runUnion
-      ( mconcat
-          [ unionAlt "Haskell2010" ( \x -> case x of Cabal.Haskell2010 -> Just () ; _ -> Nothing ) Dhall.inject
-          , unionAlt "UnknownLanguage" ( \x -> case x of Cabal.UnknownLanguage s -> Just s ; _ -> Nothing ) ( runRecordInputType ( recordField "_1" stringToDhall ) )
-          , unionAlt "Haskell98" ( \x -> case x of Cabal.Haskell98 -> Just () ; _ -> Nothing ) Dhall.inject
-          ]
-      )
-  )
-    { Dhall.declared =
+  Dhall.InputType
+    { Dhall.embed = \case
+        Cabal.Haskell2010 ->
+          lang "Haskell2010"
+        Cabal.Haskell98 ->
+          lang "Haskell98"
+        Cabal.UnknownLanguage s ->
+          Expr.App
+            ( lang "UnknownLanguage" )
+            ( Expr.RecordLit ( Map.singleton "_1" ( dhallString s ) ) )
+    , Dhall.declared =
         Expr.Var "types" `Expr.Field` "Language"
     }
+  where
+    lang name =
+      Expr.Var "types" `Expr.Field` "Language" `Expr.Field` name
 
 extension :: Dhall.InputType Cabal.Extension
 extension =

--- a/lib/CabalToDhall.hs
+++ b/lib/CabalToDhall.hs
@@ -1640,9 +1640,13 @@ versionInfo =
 
 foreignLibOption :: Dhall.InputType Cabal.ForeignLibOption
 foreignLibOption =
-  runUnion
-    ( unionAlt "Standalone" ( \x -> case x of Cabal.ForeignLibStandalone -> Just () ) Dhall.inject
-    )
+  Dhall.InputType
+    { Dhall.embed = \case
+        Cabal.ForeignLibStandalone ->
+          Expr.Var "types" `Expr.Field` "ForeignLibOption" `Expr.Field` "Standalone"
+    , Dhall.declared =
+        Expr.Var "types" `Expr.Field` "ForeignLibOption"
+    }
 
 
 foreignLibType :: Dhall.InputType Cabal.ForeignLibType

--- a/lib/DhallToCabal.hs
+++ b/lib/DhallToCabal.hs
@@ -36,6 +36,7 @@ module DhallToCabal
   , buildInfoType
   , executableScope
   , moduleRenaming
+  , foreignLibOption
 
   , sortExpr
   ) where

--- a/lib/DhallToCabal.hs
+++ b/lib/DhallToCabal.hs
@@ -37,6 +37,7 @@ module DhallToCabal
   , executableScope
   , moduleRenaming
   , foreignLibOption
+  , foreignLibType
 
   , sortExpr
   ) where


### PR DESCRIPTION
`runUnion` stops GHC helping us out with case exhaustivity checking.

In the course of making this PR and getting the benefit of GHC's assistance, I discovered that we weren't handling `AArch64` properly, which is an obvious and easily corrected oversight.

It's also made two other incomplete matches visible, but they're slightly less obviously corrected. As this PR isn't making things worse, only revealing problems that already existed, I've elected to leave those as they are.