### PR TITLE
Switch to native GitHub highlighting for .dhall

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.dhall linguist-language=Haskell


### PR DESCRIPTION
Now that https://github.com/dhall-lang/dhall-lang/issues/198 has been deployed on GItHub, we'll get proper recognition for Dhall files