### PR TITLE
Add prelude.utils.mapBuildInfo.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@
 
 * Use `dhall` version 1.25.
 
+* New utility function, `prelude.utils.mapBuildInfo`, which maps over
+  the common fields of all non-setup components.
+
 ## 1.3.4.0 -- 2019-07-05
 
 * Add compatibility for `optparse-applicative-0.15`.

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -84,216 +84,217 @@ let addWarningOptions =
 in  prelude.utils.mapBuildInfo
     addWarningOptions
     (   prelude.utils.GitHub-project
-      { owner = "ocharles", repo = "dhall-to-cabal" }
-    ⫽ { cabal-version =
-          v "2.4"
-      , synopsis =
-          "Compile Dhall expressions to Cabal files"
-      , description =
-          ''
-          dhall-to-cabal takes Dhall expressions and compiles them into Cabal
-          files. All of the features of Dhall are supported, such as let
-          bindings and imports, and all features of Cabal are supported
-          (including conditional stanzas).
-          ''
-      , category =
-          "Distribution"
-      , build-type =
-          Some types.BuildType.Simple
-      , maintainer =
-          "ollie@ocharles.org.uk"
-      , author =
-          "Ollie Charles <ollie@ocharles.org.uk>"
-      , extra-source-files =
-          [ "Changelog.md"
-          , "README.md"
-          , "dhall/**/*.dhall"
-          , "golden-tests/dhall-to-cabal/*.dhall"
-          , "golden-tests/dhall-to-cabal/*.cabal"
-          , "golden-tests/cabal-to-dhall/*.dhall"
-          , "golden-tests/cabal-to-dhall/*.cabal"
-          ]
-      , license =
-          types.License.MIT
-      , license-files =
-          [ "LICENSE" ]
-      , version =
-          v "1.3.4.0"
-      , library =
-          prelude.unconditional.library
-          (   prelude.defaults.Library
-            ⫽ { build-depends =
-                  [ deps.Cabal
-                  , deps.base
-                  , deps.bytestring
-                  , deps.containers
-                  , deps.contravariant
-                  , deps.dhall
-                  , deps.filepath
-                  , deps.microlens
-                  , deps.text
-                  , deps.transformers
-                  , deps.vector
-                  ]
-              , autogen-modules =
-                  [ "Paths_dhall_to_cabal" ]
-              , exposed-modules =
-                  [ "CabalToDhall"
-                  , "DhallLocation"
-                  , "DhallToCabal"
-                  , "DhallToCabal.FactorType"
-                  , "DhallToCabal.Util"
-                  ]
-              , hs-source-dirs =
-                  [ "lib" ]
-              , other-extensions =
-                  [ types.Extension.ApplicativeDo True
-                  , types.Extension.GADTs True
-                  , types.Extension.GeneralizedNewtypeDeriving True
-                  , types.Extension.LambdaCase True
-                  , types.Extension.OverloadedStrings True
-                  , types.Extension.RecordWildCards True
-                  , types.Extension.TypeApplications True
-                  ]
-              , other-modules =
-                  [ "DhallToCabal.ConfigTree"
-                  , "DhallToCabal.Diff"
-                  , "Dhall.Extra"
-                  , "Paths_dhall_to_cabal"
-                  ]
-              , default-language =
-                  Some types.Language.Haskell2010
-              }
-          )
-      , executables =
-          [ prelude.unconditional.executable
-            "dhall-to-cabal"
-            (   prelude.defaults.Executable
+        { owner = "ocharles", repo = "dhall-to-cabal" }
+      ⫽ { cabal-version =
+            v "2.4"
+        , synopsis =
+            "Compile Dhall expressions to Cabal files"
+        , description =
+            ''
+            dhall-to-cabal takes Dhall expressions and compiles them into Cabal
+            files. All of the features of Dhall are supported, such as let
+            bindings and imports, and all features of Cabal are supported
+            (including conditional stanzas).
+            ''
+        , category =
+            "Distribution"
+        , build-type =
+            Some types.BuildType.Simple
+        , maintainer =
+            "ollie@ocharles.org.uk"
+        , author =
+            "Ollie Charles <ollie@ocharles.org.uk>"
+        , extra-source-files =
+            [ "Changelog.md"
+            , "README.md"
+            , "dhall/**/*.dhall"
+            , "golden-tests/dhall-to-cabal/*.dhall"
+            , "golden-tests/dhall-to-cabal/*.cabal"
+            , "golden-tests/cabal-to-dhall/*.dhall"
+            , "golden-tests/cabal-to-dhall/*.cabal"
+            ]
+        , license =
+            types.License.MIT
+        , license-files =
+            [ "LICENSE" ]
+        , version =
+            v "1.3.4.0"
+        , library =
+            prelude.unconditional.library
+            (   prelude.defaults.Library
               ⫽ { build-depends =
                     [ deps.Cabal
                     , deps.base
+                    , deps.bytestring
                     , deps.containers
+                    , deps.contravariant
                     , deps.dhall
-                    , deps.dhall-to-cabal
-                    , deps.directory
                     , deps.filepath
                     , deps.microlens
-                    , deps.optparse-applicative
-                    , deps.prettyprinter
                     , deps.text
                     , deps.transformers
+                    , deps.vector
                     ]
-                , hs-source-dirs =
-                    [ "exe" ]
-                , main-is =
-                    "Main.hs"
-                , other-extensions =
-                    [ types.Extension.NamedFieldPuns True ]
-                , other-modules =
-                    [ "Paths_dhall_to_cabal" ]
                 , autogen-modules =
                     [ "Paths_dhall_to_cabal" ]
-                , default-language =
-                    Some types.Language.Haskell2010
-                }
-            )
-          , prelude.unconditional.executable
-            "cabal-to-dhall"
-            (   prelude.defaults.Executable
-              ⫽ { build-depends =
-                    [ deps.base
-                    , deps.dhall
-                    , deps.bytestring
-                    , deps.dhall-to-cabal
-                    , deps.optparse-applicative
-                    , deps.prettyprinter
-                    , deps.text
+                , exposed-modules =
+                    [ "CabalToDhall"
+                    , "DhallLocation"
+                    , "DhallToCabal"
+                    , "DhallToCabal.FactorType"
+                    , "DhallToCabal.Util"
                     ]
                 , hs-source-dirs =
-                    [ "cabal-to-dhall" ]
-                , main-is =
-                    "Main.hs"
+                    [ "lib" ]
                 , other-extensions =
-                    [ types.Extension.NamedFieldPuns True ]
+                    [ types.Extension.ApplicativeDo True
+                    , types.Extension.GADTs True
+                    , types.Extension.GeneralizedNewtypeDeriving True
+                    , types.Extension.LambdaCase True
+                    , types.Extension.OverloadedStrings True
+                    , types.Extension.RecordWildCards True
+                    , types.Extension.TypeApplications True
+                    ]
                 , other-modules =
-                    [ "Paths_dhall_to_cabal" ]
-                , autogen-modules =
-                    [ "Paths_dhall_to_cabal" ]
-                , default-language =
-                    Some types.Language.Haskell2010
-                }
-            )
-          , prelude.unconditional.executable
-            "dhall-to-cabal-meta"
-            (   prelude.defaults.Executable
-              ⫽ { scope =
-                    types.Scope.Private
-                , build-depends =
-                    [ deps.base
-                    , deps.directory
-                    , deps.dhall
-                    , deps.dhall-to-cabal
-                    , deps.filepath
-                    , deps.optparse-applicative
-                    , deps.prettyprinter
+                    [ "DhallToCabal.ConfigTree"
+                    , "DhallToCabal.Diff"
+                    , "Dhall.Extra"
+                    , "Paths_dhall_to_cabal"
                     ]
-                , hs-source-dirs =
-                    [ "meta" ]
-                , default-language =
-                    Some types.Language.Haskell2010
-                , main-is =
-                    "Main.hs"
-                }
-            )
-          ]
-      , test-suites =
-          [ prelude.unconditional.test-suite
-            "golden-tests"
-            (   prelude.defaults.TestSuite
-              ⫽ { build-depends =
-                    [ deps.base
-                    , deps.Cabal
-                    , deps.Diff
-                    , deps.bytestring
-                    , deps.dhall
-                    , deps.dhall-to-cabal
-                    , deps.filepath
-                    , deps.microlens
-                    , deps.prettyprinter
-                    , deps.tasty
-                    , deps.tasty-golden
-                    , deps.text
-                    ]
-                , hs-source-dirs =
-                    [ "golden-tests" ]
-                , type =
-                    types.TestType.exitcode-stdio { main-is = "GoldenTests.hs" }
                 , default-language =
                     Some types.Language.Haskell2010
                 }
             )
-          , prelude.unconditional.test-suite
-            "unit-tests"
-            (   prelude.defaults.TestSuite
-              ⫽ { build-depends =
-                    [ deps.base
-                    , deps.Cabal
-                    , deps.dhall
-                    , deps.dhall-to-cabal
-                    , deps.tasty
-                    , deps.tasty-hunit
-                    , deps.text
-                    ]
-                , hs-source-dirs =
-                    [ "tests" ]
-                , type =
-                    types.TestType.exitcode-stdio { main-is = "Tests.hs" }
-                , default-language =
-                    Some types.Language.Haskell2010
-                , other-modules =
-                    [ "DhallToCabal.Tests" ]
-                }
-            )
-          ]
-      }
-)
+        , executables =
+            [ prelude.unconditional.executable
+              "dhall-to-cabal"
+              (   prelude.defaults.Executable
+                ⫽ { build-depends =
+                      [ deps.Cabal
+                      , deps.base
+                      , deps.containers
+                      , deps.dhall
+                      , deps.dhall-to-cabal
+                      , deps.directory
+                      , deps.filepath
+                      , deps.microlens
+                      , deps.optparse-applicative
+                      , deps.prettyprinter
+                      , deps.text
+                      , deps.transformers
+                      ]
+                  , hs-source-dirs =
+                      [ "exe" ]
+                  , main-is =
+                      "Main.hs"
+                  , other-extensions =
+                      [ types.Extension.NamedFieldPuns True ]
+                  , other-modules =
+                      [ "Paths_dhall_to_cabal" ]
+                  , autogen-modules =
+                      [ "Paths_dhall_to_cabal" ]
+                  , default-language =
+                      Some types.Language.Haskell2010
+                  }
+              )
+            , prelude.unconditional.executable
+              "cabal-to-dhall"
+              (   prelude.defaults.Executable
+                ⫽ { build-depends =
+                      [ deps.base
+                      , deps.dhall
+                      , deps.bytestring
+                      , deps.dhall-to-cabal
+                      , deps.optparse-applicative
+                      , deps.prettyprinter
+                      , deps.text
+                      ]
+                  , hs-source-dirs =
+                      [ "cabal-to-dhall" ]
+                  , main-is =
+                      "Main.hs"
+                  , other-extensions =
+                      [ types.Extension.NamedFieldPuns True ]
+                  , other-modules =
+                      [ "Paths_dhall_to_cabal" ]
+                  , autogen-modules =
+                      [ "Paths_dhall_to_cabal" ]
+                  , default-language =
+                      Some types.Language.Haskell2010
+                  }
+              )
+            , prelude.unconditional.executable
+              "dhall-to-cabal-meta"
+              (   prelude.defaults.Executable
+                ⫽ { scope =
+                      types.Scope.Private
+                  , build-depends =
+                      [ deps.base
+                      , deps.directory
+                      , deps.dhall
+                      , deps.dhall-to-cabal
+                      , deps.filepath
+                      , deps.optparse-applicative
+                      , deps.prettyprinter
+                      ]
+                  , hs-source-dirs =
+                      [ "meta" ]
+                  , default-language =
+                      Some types.Language.Haskell2010
+                  , main-is =
+                      "Main.hs"
+                  }
+              )
+            ]
+        , test-suites =
+            [ prelude.unconditional.test-suite
+              "golden-tests"
+              (   prelude.defaults.TestSuite
+                ⫽ { build-depends =
+                      [ deps.base
+                      , deps.Cabal
+                      , deps.Diff
+                      , deps.bytestring
+                      , deps.dhall
+                      , deps.dhall-to-cabal
+                      , deps.filepath
+                      , deps.microlens
+                      , deps.prettyprinter
+                      , deps.tasty
+                      , deps.tasty-golden
+                      , deps.text
+                      ]
+                  , hs-source-dirs =
+                      [ "golden-tests" ]
+                  , type =
+                      types.TestType.exitcode-stdio
+                      { main-is = "GoldenTests.hs" }
+                  , default-language =
+                      Some types.Language.Haskell2010
+                  }
+              )
+            , prelude.unconditional.test-suite
+              "unit-tests"
+              (   prelude.defaults.TestSuite
+                ⫽ { build-depends =
+                      [ deps.base
+                      , deps.Cabal
+                      , deps.dhall
+                      , deps.dhall-to-cabal
+                      , deps.tasty
+                      , deps.tasty-hunit
+                      , deps.text
+                      ]
+                  , hs-source-dirs =
+                      [ "tests" ]
+                  , type =
+                      types.TestType.exitcode-stdio { main-is = "Tests.hs" }
+                  , default-language =
+                      Some types.Language.Haskell2010
+                  , other-modules =
+                      [ "DhallToCabal.Tests" ]
+                  }
+              )
+            ]
+        }
+    )

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -73,7 +73,17 @@ let warning-options =
       , "-fno-warn-name-shadowing"
       ]
 
-in    prelude.utils.GitHub-project
+let addWarningOptions =
+        λ(component : types.BuildInfo)
+      →   component
+        ⫽ { compiler-options =
+                component.compiler-options
+              ⫽ { GHC = component.compiler-options.GHC # warning-options }
+          }
+
+in  prelude.utils.mapBuildInfo
+    addWarningOptions
+    (   prelude.utils.GitHub-project
       { owner = "ocharles", repo = "dhall-to-cabal" }
     ⫽ { cabal-version =
           v "2.4"
@@ -125,8 +135,6 @@ in    prelude.utils.GitHub-project
                   , deps.transformers
                   , deps.vector
                   ]
-              , compiler-options =
-                  prelude.defaults.CompilerOptions ⫽ { GHC = warning-options }
               , autogen-modules =
                   [ "Paths_dhall_to_cabal" ]
               , exposed-modules =
@@ -175,8 +183,6 @@ in    prelude.utils.GitHub-project
                     , deps.text
                     , deps.transformers
                     ]
-                , compiler-options =
-                    prelude.defaults.CompilerOptions ⫽ { GHC = warning-options }
                 , hs-source-dirs =
                     [ "exe" ]
                 , main-is =
@@ -203,8 +209,6 @@ in    prelude.utils.GitHub-project
                     , deps.prettyprinter
                     , deps.text
                     ]
-                , compiler-options =
-                    prelude.defaults.CompilerOptions ⫽ { GHC = warning-options }
                 , hs-source-dirs =
                     [ "cabal-to-dhall" ]
                 , main-is =
@@ -237,8 +241,6 @@ in    prelude.utils.GitHub-project
                     [ "meta" ]
                 , default-language =
                     Some types.Language.Haskell2010
-                , compiler-options =
-                    prelude.defaults.CompilerOptions ⫽ { GHC = warning-options }
                 , main-is =
                     "Main.hs"
                 }
@@ -262,8 +264,6 @@ in    prelude.utils.GitHub-project
                     , deps.tasty-golden
                     , deps.text
                     ]
-                , compiler-options =
-                    prelude.defaults.CompilerOptions ⫽ { GHC = warning-options }
                 , hs-source-dirs =
                     [ "golden-tests" ]
                 , type =
@@ -284,8 +284,6 @@ in    prelude.utils.GitHub-project
                     , deps.tasty-hunit
                     , deps.text
                     ]
-                , compiler-options =
-                    prelude.defaults.CompilerOptions ⫽ { GHC = warning-options }
                 , hs-source-dirs =
                     [ "tests" ]
                 , type =
@@ -298,3 +296,4 @@ in    prelude.utils.GitHub-project
             )
           ]
       }
+)

--- a/dhall/types.dhall
+++ b/dhall/types.dhall
@@ -2,6 +2,8 @@
     ./types/Arch.dhall
 , Benchmark =
     ./types/Benchmark.dhall
+, BuildInfo =
+    ./types/BuildInfo.dhall
 , BuildType =
     ./types/BuildType.dhall
 , Compiler =

--- a/dhall/utils/mapBuildInfo.dhall
+++ b/dhall/utils/mapBuildInfo.dhall
@@ -1,0 +1,128 @@
+let types = ../types.dhall
+
+let mapOptional = https://prelude.dhall-lang.org/v8.0.0/Optional/map
+
+let mapList = https://prelude.dhall-lang.org/v8.0.0/List/map
+
+let mapGuarded =
+        λ(a : Type)
+      → λ(f : a → a)
+      → λ(x : types.Config → a)
+      → λ(config : types.Config)
+      → f (x config)
+
+let NamedGuardedExecutable =
+      { name : Text, executable : types.Config → types.Executable }
+
+let NamedGuardedLibrary =
+      { name : Text, library : types.Config → types.Library }
+
+let NamedGuardedTestSuite =
+      { name : Text, test-suite : types.Config → types.TestSuite }
+
+let NamedGuardedBenchmark =
+      { name : Text, benchmark : types.Config → types.Benchmark }
+
+let NamedGuardedForeignLibrary =
+      { name : Text, foreign-lib : types.Config → types.ForeignLibrary }
+
+in    λ(f : types.BuildInfo → types.BuildInfo)
+    → λ(package : types.Package)
+    →   package
+      ⫽ { library =
+            mapOptional
+            (types.Config → types.Library)
+            (types.Config → types.Library)
+            ( mapGuarded
+              types.Library
+              (   λ(component : types.Library)
+                → component ⫽ f component.(types.BuildInfo)
+              )
+            )
+            package.library
+        , executables =
+            mapList
+            NamedGuardedExecutable
+            NamedGuardedExecutable
+            (   λ(namedGuardedExecutable : NamedGuardedExecutable)
+              → { name =
+                    namedGuardedExecutable.name
+                , executable =
+                    mapGuarded
+                    types.Executable
+                    (   λ(component : types.Executable)
+                      → component ⫽ f component.(types.BuildInfo)
+                    )
+                    namedGuardedExecutable.executable
+                }
+            )
+            package.executables
+        , sub-libraries =
+            mapList
+            NamedGuardedLibrary
+            NamedGuardedLibrary
+            (   λ(namedGuardedLibrary : NamedGuardedLibrary)
+              → { name =
+                    namedGuardedLibrary.name
+                , library =
+                    mapGuarded
+                    types.Library
+                    (   λ(component : types.Library)
+                      → component ⫽ f component.(types.BuildInfo)
+                    )
+                    namedGuardedLibrary.library
+                }
+            )
+            package.sub-libraries
+        , test-suites =
+            mapList
+            NamedGuardedTestSuite
+            NamedGuardedTestSuite
+            (   λ(namedGuardedTestSuite : NamedGuardedTestSuite)
+              → { name =
+                    namedGuardedTestSuite.name
+                , test-suite =
+                    mapGuarded
+                    types.TestSuite
+                    (   λ(component : types.TestSuite)
+                      → component ⫽ f component.(types.BuildInfo)
+                    )
+                    namedGuardedTestSuite.test-suite
+                }
+            )
+            package.test-suites
+        , benchmarks =
+            mapList
+            NamedGuardedBenchmark
+            NamedGuardedBenchmark
+            (   λ(namedGuardedBenchmark : NamedGuardedBenchmark)
+              → { name =
+                    namedGuardedBenchmark.name
+                , benchmark =
+                    mapGuarded
+                    types.Benchmark
+                    (   λ(component : types.Benchmark)
+                      → component ⫽ f component.(types.BuildInfo)
+                    )
+                    namedGuardedBenchmark.benchmark
+                }
+            )
+            package.benchmarks
+        , foreign-libraries =
+            mapList
+            NamedGuardedForeignLibrary
+            NamedGuardedForeignLibrary
+            (   λ(namedGuardedForeignLibrary : NamedGuardedForeignLibrary)
+              → { name =
+                    namedGuardedForeignLibrary.name
+                , foreign-lib =
+                    mapGuarded
+                    types.ForeignLibrary
+                    (   λ(component : types.ForeignLibrary)
+                      → component ⫽ f component.(types.BuildInfo)
+                    )
+                    namedGuardedForeignLibrary.foreign-lib
+                }
+            )
+            package.foreign-libraries
+        }

--- a/dhall/utils/package.dhall
+++ b/dhall/utils/package.dhall
@@ -2,6 +2,8 @@
     ./GitHub-project.dhall
 , majorVersions =
     ./majorVersions.dhall
+, mapBuildInfo =
+    ./mapBuildInfo.dhall
 , mapSourceRepos =
     ./mapSourceRepos.dhall
 }

--- a/golden-tests/dhall-to-cabal/map-build-info.cabal
+++ b/golden-tests/dhall-to-cabal/map-build-info.cabal
@@ -1,0 +1,42 @@
+cabal-version: 2.2
+name: pkg
+version: 0
+
+custom-setup
+    setup-depends: setup ^>=1.0
+
+library
+    build-depends:
+        library ^>=1.0,
+        injected ^>=1.0
+
+library sublib
+    build-depends:
+        sublib ^>=1.0,
+        injected ^>=1.0
+
+foreign-library flib
+    type: native-static
+    build-depends:
+        flib ^>=1.0,
+        injected ^>=1.0
+
+executable exe
+    main-is: Exe.hs
+    build-depends:
+        exe ^>=1.0,
+        injected ^>=1.0
+
+test-suite tests
+    type: exitcode-stdio-1.0
+    main-is: Test.hs
+    build-depends:
+        tests ^>=1.0,
+        injected ^>=1.0
+
+benchmark bench
+    type: exitcode-stdio-1.0
+    main-is: Bench.hs
+    build-depends:
+        bench ^>=1.0,
+        injected ^>=1.0

--- a/golden-tests/dhall-to-cabal/map-build-info.dhall
+++ b/golden-tests/dhall-to-cabal/map-build-info.dhall
@@ -1,0 +1,118 @@
+let prelude = ../../dhall/prelude.dhall
+
+let types = ../../dhall/types.dhall
+
+let f =
+        λ(buildInfo : types.BuildInfo)
+      →   buildInfo
+        ⫽ { build-depends =
+                buildInfo.build-depends
+              # [ prelude.utils.majorVersions "injected" [ prelude.v "1.0" ] ]
+          }
+
+in  prelude.utils.mapBuildInfo
+    f
+    (   prelude.defaults.Package
+      ⫽ { name =
+            "pkg"
+        , version =
+            prelude.v "0"
+        , library =
+            Some
+            (   λ(config : types.Config)
+              →   prelude.defaults.Library
+                ⫽ { build-depends =
+                      [ prelude.utils.majorVersions
+                        "library"
+                        [ prelude.v "1.0" ]
+                      ]
+                  }
+            )
+        , custom-setup =
+            Some
+            { setup-depends =
+                [ prelude.utils.majorVersions "setup" [ prelude.v "1.0" ] ]
+            }
+        , benchmarks =
+            [ { name =
+                  "bench"
+              , benchmark =
+                    λ(config : types.Config)
+                  →   prelude.defaults.Benchmark
+                    ⫽ { main-is =
+                          "Bench.hs"
+                      , build-depends =
+                          [ prelude.utils.majorVersions
+                            "bench"
+                            [ prelude.v "1.0" ]
+                          ]
+                      }
+              }
+            ]
+        , executables =
+            [ { name =
+                  "exe"
+              , executable =
+                    λ(config : types.Config)
+                  →   prelude.defaults.Executable
+                    ⫽ { main-is =
+                          "Exe.hs"
+                      , build-depends =
+                          [ prelude.utils.majorVersions
+                            "exe"
+                            [ prelude.v "1.0" ]
+                          ]
+                      }
+              }
+            ]
+        , foreign-libraries =
+            [ { name =
+                  "flib"
+              , foreign-lib =
+                    λ(config : types.Config)
+                  →   ../../dhall/defaults/BuildInfo.dhall
+                    ⫽ { type = types.ForeignLibType.Static
+                      , options = [] : List types.ForeignLibOption
+                      , mod-def-files = [] : List Text
+                      , lib-version-info = None { current : Natural, revision : Natural, age : Natural }
+                      , lib-version-linux = None types.Version
+                      , build-depends =
+                          [ prelude.utils.majorVersions
+                            "flib"
+                            [ prelude.v "1.0" ]
+                          ]
+                      }
+              }
+            ]
+        , sub-libraries =
+            [ { name =
+                  "sublib"
+              , library =
+                    λ(config : types.Config)
+                  →   prelude.defaults.Library
+                    ⫽ { build-depends =
+                          [ prelude.utils.majorVersions
+                            "sublib"
+                            [ prelude.v "1.0" ]
+                          ]
+                      }
+              }
+            ]
+        , test-suites =
+            [ { name =
+                  "tests"
+              , test-suite =
+                    λ(config : types.Config)
+                  →   prelude.defaults.TestSuite
+                    ⫽ { type =
+                          types.TestType.exitcode-stdio { main-is = "Test.hs" }
+                      , build-depends =
+                          [ prelude.utils.majorVersions
+                            "tests"
+                            [ prelude.v "1.0" ]
+                          ]
+                      }
+              }
+            ]
+        }
+    )


### PR DESCRIPTION
IMO, this is a function that highlights how `dhall-to-cabal` is an advance on `hpack`: the best feature of `hpack`, setting `ghc-options` at the top level and then having them apply to all components without any per-component effort, is now really easy to implement. It was writable before the latest Dhall version, but record projection by expression turns it from horrible to just mildly repetetive.

Tests are actually passing but I don't think its ready to merge on two counts:

* dhall-lang/dhall-haskell#1009 means that, in `mapBuildInfo.dhall`, the `BuildInfo` used as a field selector has to be an import. This hack is localised and could be noted for later removal and then merged, but...

* We'll want to work out what to do about the imports from Dhall's prelude. I don't really like the option of leaving them as HTTP URLs. Including the prelude as a submodule would be a bit awkward, not least because, as the files are extensionless, we can't use Cabal's wildcards to include them in `extra-source-files`. (haskell/cabal#5883 is the discussion on lifting that requirement.) Also, submodules are terrible and are always breaking in inscrutable ways. I guess that that leaves directly copying the functions that are used?