### PR TITLE
 Use mapBuildInfo to extract more common build-info fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 dist-newstyle/
 .stack-work/
 .ghc.environment.*
+stack.yaml.lock

--- a/dhall-to-cabal.cabal
+++ b/dhall-to-cabal.cabal
@@ -62,12 +62,12 @@ library
                  -Wno-missing-local-signatures -Wno-monomorphism-restriction
                  -fno-warn-name-shadowing
     build-depends:
-        Cabal ^>=2.4,
         base ^>=4.10 || ^>=4.11 || ^>=4.12,
+        dhall ^>=1.25.0,
+        Cabal ^>=2.4,
         bytestring ^>=0.10,
         containers ^>=0.5 || ^>=0.6,
         contravariant ^>=1.4 || ^>=1.5,
-        dhall ^>=1.25.0,
         filepath ^>=1.4,
         microlens ^>=0.1.0.0 || ^>=0.2.0.0 || ^>=0.3.0.0 || ^>=0.4.0.0,
         text ^>=1.2,
@@ -89,10 +89,10 @@ executable dhall-to-cabal
                  -Wno-missing-local-signatures -Wno-monomorphism-restriction
                  -fno-warn-name-shadowing
     build-depends:
-        Cabal ^>=2.4,
         base ^>=4.10 || ^>=4.11 || ^>=4.12,
-        containers ^>=0.5 || ^>=0.6,
         dhall ^>=1.25.0,
+        Cabal ^>=2.4,
+        containers ^>=0.5 || ^>=0.6,
         dhall-to-cabal -any,
         directory ^>=1.3.0.2,
         filepath ^>=1.4,
@@ -137,8 +137,8 @@ executable dhall-to-cabal-meta
                  -fno-warn-name-shadowing
     build-depends:
         base ^>=4.10 || ^>=4.11 || ^>=4.12,
-        directory ^>=1.3.0.2,
         dhall ^>=1.25.0,
+        directory ^>=1.3.0.2,
         dhall-to-cabal -any,
         filepath ^>=1.4,
         optparse-applicative ^>=0.13.2 || ^>=0.14 || ^>=0.15,
@@ -156,10 +156,10 @@ test-suite golden-tests
                  -fno-warn-name-shadowing
     build-depends:
         base ^>=4.10 || ^>=4.11 || ^>=4.12,
+        dhall ^>=1.25.0,
         Cabal ^>=2.4,
         Diff ^>=0.3.4,
         bytestring ^>=0.10,
-        dhall ^>=1.25.0,
         dhall-to-cabal -any,
         filepath ^>=1.4,
         microlens ^>=0.1.0.0 || ^>=0.2.0.0 || ^>=0.3.0.0 || ^>=0.4.0.0,
@@ -182,8 +182,8 @@ test-suite unit-tests
                  -fno-warn-name-shadowing
     build-depends:
         base ^>=4.10 || ^>=4.11 || ^>=4.12,
-        Cabal ^>=2.4,
         dhall ^>=1.25.0,
+        Cabal ^>=2.4,
         dhall-to-cabal -any,
         tasty ^>=0.11 || ^>=0.12 || ^>=1.0 || ^>=1.1 || ^>=1.2,
         tasty-hunit ^>=0.10.0.1,

--- a/dhall-to-cabal.dhall
+++ b/dhall-to-cabal.dhall
@@ -73,16 +73,20 @@ let warning-options =
       , "-fno-warn-name-shadowing"
       ]
 
-let addWarningOptions =
+let addCommonBuildInfo =
         λ(component : types.BuildInfo)
       →   component
         ⫽ { compiler-options =
                 component.compiler-options
               ⫽ { GHC = component.compiler-options.GHC # warning-options }
+          , build-depends =
+              [ deps.base, deps.dhall ] # component.build-depends
+          , default-language =
+              Some types.Language.Haskell2010
           }
 
 in  prelude.utils.mapBuildInfo
-    addWarningOptions
+    addCommonBuildInfo
     (   prelude.utils.GitHub-project
         { owner = "ocharles", repo = "dhall-to-cabal" }
       ⫽ { cabal-version =
@@ -124,11 +128,9 @@ in  prelude.utils.mapBuildInfo
             (   prelude.defaults.Library
               ⫽ { build-depends =
                     [ deps.Cabal
-                    , deps.base
                     , deps.bytestring
                     , deps.containers
                     , deps.contravariant
-                    , deps.dhall
                     , deps.filepath
                     , deps.microlens
                     , deps.text
@@ -161,8 +163,6 @@ in  prelude.utils.mapBuildInfo
                     , "Dhall.Extra"
                     , "Paths_dhall_to_cabal"
                     ]
-                , default-language =
-                    Some types.Language.Haskell2010
                 }
             )
         , executables =
@@ -171,9 +171,7 @@ in  prelude.utils.mapBuildInfo
               (   prelude.defaults.Executable
                 ⫽ { build-depends =
                       [ deps.Cabal
-                      , deps.base
                       , deps.containers
-                      , deps.dhall
                       , deps.dhall-to-cabal
                       , deps.directory
                       , deps.filepath
@@ -193,17 +191,13 @@ in  prelude.utils.mapBuildInfo
                       [ "Paths_dhall_to_cabal" ]
                   , autogen-modules =
                       [ "Paths_dhall_to_cabal" ]
-                  , default-language =
-                      Some types.Language.Haskell2010
                   }
               )
             , prelude.unconditional.executable
               "cabal-to-dhall"
               (   prelude.defaults.Executable
                 ⫽ { build-depends =
-                      [ deps.base
-                      , deps.dhall
-                      , deps.bytestring
+                      [ deps.bytestring
                       , deps.dhall-to-cabal
                       , deps.optparse-applicative
                       , deps.prettyprinter
@@ -219,8 +213,6 @@ in  prelude.utils.mapBuildInfo
                       [ "Paths_dhall_to_cabal" ]
                   , autogen-modules =
                       [ "Paths_dhall_to_cabal" ]
-                  , default-language =
-                      Some types.Language.Haskell2010
                   }
               )
             , prelude.unconditional.executable
@@ -229,9 +221,7 @@ in  prelude.utils.mapBuildInfo
                 ⫽ { scope =
                       types.Scope.Private
                   , build-depends =
-                      [ deps.base
-                      , deps.directory
-                      , deps.dhall
+                      [ deps.directory
                       , deps.dhall-to-cabal
                       , deps.filepath
                       , deps.optparse-applicative
@@ -239,8 +229,6 @@ in  prelude.utils.mapBuildInfo
                       ]
                   , hs-source-dirs =
                       [ "meta" ]
-                  , default-language =
-                      Some types.Language.Haskell2010
                   , main-is =
                       "Main.hs"
                   }
@@ -251,11 +239,9 @@ in  prelude.utils.mapBuildInfo
               "golden-tests"
               (   prelude.defaults.TestSuite
                 ⫽ { build-depends =
-                      [ deps.base
-                      , deps.Cabal
+                      [ deps.Cabal
                       , deps.Diff
                       , deps.bytestring
-                      , deps.dhall
                       , deps.dhall-to-cabal
                       , deps.filepath
                       , deps.microlens
@@ -269,17 +255,13 @@ in  prelude.utils.mapBuildInfo
                   , type =
                       types.TestType.exitcode-stdio
                       { main-is = "GoldenTests.hs" }
-                  , default-language =
-                      Some types.Language.Haskell2010
                   }
               )
             , prelude.unconditional.test-suite
               "unit-tests"
               (   prelude.defaults.TestSuite
                 ⫽ { build-depends =
-                      [ deps.base
-                      , deps.Cabal
-                      , deps.dhall
+                      [ deps.Cabal
                       , deps.dhall-to-cabal
                       , deps.tasty
                       , deps.tasty-hunit
@@ -289,8 +271,6 @@ in  prelude.utils.mapBuildInfo
                       [ "tests" ]
                   , type =
                       types.TestType.exitcode-stdio { main-is = "Tests.hs" }
-                  , default-language =
-                      Some types.Language.Haskell2010
                   , other-modules =
                       [ "DhallToCabal.Tests" ]
                   }


### PR DESCRIPTION
* It extracts the common dependencies and `default-language`: the benefit is not terrible but i think it shows the potential of the new function added by @quasicomputational 